### PR TITLE
Fix github link

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -25,7 +25,7 @@ navbar:
       href: https://yiqingxu.org/papers/english/2022_fect/LWX2022.pdf
   right:
    - icon: fa-github
-     href: https://github.com/xuyiqing/interflex
+     href: https://github.com/xuyiqing/fect
 
 footer:
   structure:


### PR DESCRIPTION
The github link on the fect doc links to `interflex`