### PR TITLE
fix: add explicit data() calls for new datasets in vignettes

### DIFF
--- a/vignettes/01-start.Rmd
+++ b/vignettes/01-start.Rmd
@@ -62,6 +62,11 @@ The **fect** package ships several datasets. All simulated and empirical dataset
 ```{r load-data, message = FALSE, warning = FALSE}
 library(fect)
 data(fect)
+data(sim_base)
+data(sim_gsynth)
+data(sim_linear)
+data(sim_trend)
+data(sim_region)
 ls()
 ```
 

--- a/vignettes/02-fect.Rmd
+++ b/vignettes/02-fect.Rmd
@@ -16,6 +16,8 @@ rm(list = ls())
 ```{r load-packages, message = FALSE, warning = FALSE}
 library(fect)
 data(fect)
+data(sim_base)
+data(sim_gsynth)
 ```
 
 We use the **panelView** package to visualize the treatment and outcome variables:

--- a/vignettes/04-cfe.Rmd
+++ b/vignettes/04-cfe.Rmd
@@ -12,6 +12,9 @@ rm(list = ls())
 ```{r load-packages-cfe, message = FALSE, warning = FALSE}
 library(fect)
 data(fect)
+data(sim_region)
+data(sim_linear)
+data(sim_trend)
 ```
 
 ------------------------------------------------------------------------

--- a/vignettes/05-hte.Rmd
+++ b/vignettes/05-hte.Rmd
@@ -4,6 +4,7 @@
 set.seed(1234)
 library(fect)
 data(fect)
+data(sim_base)
 ```
 
 We provide several methods for researchers to explore heterogeneous treatment effects (HTE). These methods help distinguish between *effect modification* --- how the treatment effect varies across subpopulations --- and *causal moderation* --- whether changing the moderator causally alters the treatment effect. This chapter demonstrates both descriptive HTE tools and the formal causal moderation framework. R script used in this chapter can be downloaded [here](https://raw.githubusercontent.com/xuyiqing/fect/dev/vignettes/rscript/05-hte.R).

--- a/vignettes/07-gsynth.Rmd
+++ b/vignettes/07-gsynth.Rmd
@@ -36,6 +36,7 @@ rm(list = ls())
 ```{r load-packages, warning=FALSE, message=FALSE}
 library(fect)
 data(fect)
+data(sim_gsynth)
 ls()
 ```
 


### PR DESCRIPTION
fect.RData only contains legacy datasets (simdata, simgsynth, hh2019, gs2020, turnout). The new datasets (sim_base, sim_gsynth, sim_linear, sim_trend, sim_region) exist as separate .rda files but were not loaded by data(fect). After rm(list = ls()), these datasets became unavailable causing "object not found" errors during quarto render.

https://claude.ai/code/session_014ctjR27HYMWhCzsP5jesLW