### PR TITLE
fix: load data from source tree for local quarto render

### DIFF
--- a/vignettes/01-start.Rmd
+++ b/vignettes/01-start.Rmd
@@ -61,12 +61,15 @@ The **fect** package ships several datasets. All simulated and empirical dataset
 
 ```{r load-data, message = FALSE, warning = FALSE}
 library(fect)
-data(fect)
-data(sim_base)
-data(sim_gsynth)
-data(sim_linear)
-data(sim_trend)
-data(sim_region)
+if (dir.exists("../data")) {
+  load("../data/fect.RData")
+  for (.f in list.files("../data", pattern = "\\.rda$", full.names = TRUE))
+    load(.f)
+  rm(.f)
+} else {
+  data(fect)
+  data(sim_base); data(sim_gsynth); data(sim_linear); data(sim_trend); data(sim_region)
+}
 ls()
 ```
 

--- a/vignettes/02-fect.Rmd
+++ b/vignettes/02-fect.Rmd
@@ -15,9 +15,13 @@ rm(list = ls())
 
 ```{r load-packages, message = FALSE, warning = FALSE}
 library(fect)
-data(fect)
-data(sim_base)
-data(sim_gsynth)
+if (dir.exists("../data")) {
+  load("../data/fect.RData")
+  load("../data/sim_base.rda")
+  load("../data/sim_gsynth.rda")
+} else {
+  data(fect); data(sim_base); data(sim_gsynth)
+}
 ```
 
 We use the **panelView** package to visualize the treatment and outcome variables:

--- a/vignettes/03-ife-mc.Rmd
+++ b/vignettes/03-ife-mc.Rmd
@@ -3,7 +3,7 @@
 ```{r setup-ife-mc, echo = FALSE, message = FALSE, warning = FALSE}
 set.seed(1234)
 library(fect)
-data(fect)
+if (dir.exists("../data")) load("../data/fect.RData") else data(fect)
 ```
 
 When the parallel trends assumption is violated due to latent common factors with heterogeneous loadings, the FE estimator from [Chapter @sec-fect] is biased. This chapter introduces two methods that account for such latent factors: the **interactive fixed effects** (IFE) method, which explicitly models unit-specific factor loadings, and the **matrix completion** (MC) method, which uses nuclear-norm regularization to recover the low-rank structure of the untreated potential outcomes. R script used in this chapter can be downloaded [here](https://raw.githubusercontent.com/xuyiqing/fect/dev/vignettes/rscript/03-ife-mc.R).

--- a/vignettes/04-cfe.Rmd
+++ b/vignettes/04-cfe.Rmd
@@ -11,10 +11,14 @@ rm(list = ls())
 
 ```{r load-packages-cfe, message = FALSE, warning = FALSE}
 library(fect)
-data(fect)
-data(sim_region)
-data(sim_linear)
-data(sim_trend)
+if (dir.exists("../data")) {
+  load("../data/fect.RData")
+  load("../data/sim_region.rda")
+  load("../data/sim_linear.rda")
+  load("../data/sim_trend.rda")
+} else {
+  data(fect); data(sim_region); data(sim_linear); data(sim_trend)
+}
 ```
 
 ------------------------------------------------------------------------

--- a/vignettes/05-hte.Rmd
+++ b/vignettes/05-hte.Rmd
@@ -3,8 +3,12 @@
 ```{r setup-hte, echo = FALSE, message = FALSE, warning = FALSE}
 set.seed(1234)
 library(fect)
-data(fect)
-data(sim_base)
+if (dir.exists("../data")) {
+  load("../data/fect.RData")
+  load("../data/sim_base.rda")
+} else {
+  data(fect); data(sim_base)
+}
 ```
 
 We provide several methods for researchers to explore heterogeneous treatment effects (HTE). These methods help distinguish between *effect modification* --- how the treatment effect varies across subpopulations --- and *causal moderation* --- whether changing the moderator causally alters the treatment effect. This chapter demonstrates both descriptive HTE tools and the formal causal moderation framework. R script used in this chapter can be downloaded [here](https://raw.githubusercontent.com/xuyiqing/fect/dev/vignettes/rscript/05-hte.R).

--- a/vignettes/06-plots.Rmd
+++ b/vignettes/06-plots.Rmd
@@ -23,7 +23,7 @@ We use two datasets throughout. @GS2020 examines the mobilizing effect of minori
 library(ggplot2)
 library(panelView)
 library(fect)
-data(fect)
+if (dir.exists("../data")) load("../data/fect.RData") else data(fect)
 ls()
 ```
 

--- a/vignettes/07-gsynth.Rmd
+++ b/vignettes/07-gsynth.Rmd
@@ -35,8 +35,12 @@ rm(list = ls())
 
 ```{r load-packages, warning=FALSE, message=FALSE}
 library(fect)
-data(fect)
-data(sim_gsynth)
+if (dir.exists("../data")) {
+  load("../data/fect.RData")
+  load("../data/sim_gsynth.rda")
+} else {
+  data(fect); data(sim_gsynth)
+}
 ls()
 ```
 

--- a/vignettes/08-panel.Rmd
+++ b/vignettes/08-panel.Rmd
@@ -76,7 +76,7 @@ We begin with an empirical example from @HH2019, who investigate the effects of 
 The study finds that switching from direct to indirect democracy increased naturalization rates by an average of 1.22 percentage points (Model 1, Table 1).
 
 ```{r load-hh2019, message = FALSE, warning = FALSE}
-data(fect)
+if (dir.exists("../data")) load("../data/fect.RData") else data(fect)
 data <- hh2019
 head(data)
 ```
@@ -674,7 +674,7 @@ House general elections between 1980 and 2012, arguing that the presence of Asia
 Here, we focus specifically on the effects of Asian candidates, as shown in the top left panel of Figure 5 in the paper.
 
 ```{r load-gs2020, message = FALSE, warning = FALSE}
-data(fect)
+if (dir.exists("../data")) load("../data/fect.RData") else data(fect)
 data <- gs2020
 data$cycle <- as.integer(as.numeric(data$cycle/2))
 head(data)

--- a/vignettes/09-sens.Rmd
+++ b/vignettes/09-sens.Rmd
@@ -44,7 +44,7 @@ library(HonestDiDFEct) # Required for fect_sens to work
 We begin with an empirical example from @HH2019, who investigate the effects of indirect democracy versus direct democracy on naturalization rates in Switzerland using municipality-year panel data from 1991 to 2009. The study finds that switching from direct to indirect democracy increased naturalization rates by an average of 1.22 percentage points (Model 1, Table 1).
 
 ```{r load-hh2019, message = FALSE, warning = FALSE}
-data(fect)
+if (dir.exists("../data")) load("../data/fect.RData") else data(fect)
 data <- hh2019
 head(data)
 ```


### PR DESCRIPTION
data(fect) / data(sim_base) only works when the installed package contains the data files. For local quarto render from the source tree (where the installed package may be outdated), load .rda/.RData files directly from ../data/. Falls back to data() for R CMD check where the package is freshly installed.

https://claude.ai/code/session_014ctjR27HYMWhCzsP5jesLW