### PR TITLE
fix: use devtools::load_all() for local quarto rendering

### DIFF
--- a/man/fect.Rd
+++ b/man/fect.Rd
@@ -29,7 +29,9 @@ assumptions.}
             balance.period = NULL, fill.missing = FALSE,
             placeboTest = FALSE, placebo.period = NULL,
             carryoverTest = FALSE, carryover.period = NULL, carryover.rm = NULL,
-            loo = FALSE, permute = FALSE, m = 2, normalize = FALSE, keep.sims = FALSE, cm = FALSE)}
+            loo = FALSE, permute = FALSE, m = 2,
+            normalize = FALSE, keep.sims = FALSE,
+            cm = FALSE)}
 \arguments{
 \item{formula}{an object of class "formula": a symbolic description of the model to be fitted, e.g, Y~D+X1+X2}
 \item{data}{a data frame, can be a balanced or unbalanced panel data.}

--- a/vignettes/01-start.Rmd
+++ b/vignettes/01-start.Rmd
@@ -2,6 +2,10 @@
 
 This chapter provides installation instructions and introduces the datasets used in the tutorial.
 
+```{r .common, include = FALSE}
+source("_common.R")
+```
+
 ```{r clear-environment, echo = FALSE}
 rm(list = ls())
 ```
@@ -61,15 +65,12 @@ The **fect** package ships several datasets. All simulated and empirical dataset
 
 ```{r load-data, message = FALSE, warning = FALSE}
 library(fect)
-if (dir.exists("../data")) {
-  load("../data/fect.RData")
-  for (.f in list.files("../data", pattern = "\\.rda$", full.names = TRUE))
-    load(.f)
-  rm(.f)
-} else {
-  data(fect)
-  data(sim_base); data(sim_gsynth); data(sim_linear); data(sim_trend); data(sim_region)
-}
+data(fect)
+data(sim_base)
+data(sim_gsynth)
+data(sim_linear)
+data(sim_trend)
+data(sim_region)
 ls()
 ```
 

--- a/vignettes/02-fect.Rmd
+++ b/vignettes/02-fect.Rmd
@@ -8,20 +8,19 @@ In this chapter, we use `sim_base`, a simulated panel dataset in which the paral
 
 Since there are no latent factors, the `"fe"` method (two-way fixed effects counterfactual estimator, or FEct) is correctly specified for this DGP. For settings where latent factors are present and the FE estimator is biased, see [Chapter @sec-ife-mc].
 
+```{r .common, include = FALSE}
+source("_common.R")
+```
+
 ```{r setup-seed, echo = FALSE}
 set.seed(1234)
-rm(list = ls())
 ```
 
 ```{r load-packages, message = FALSE, warning = FALSE}
 library(fect)
-if (dir.exists("../data")) {
-  load("../data/fect.RData")
-  load("../data/sim_base.rda")
-  load("../data/sim_gsynth.rda")
-} else {
-  data(fect); data(sim_base); data(sim_gsynth)
-}
+data(fect)
+data(sim_base)
+data(sim_gsynth)
 ```
 
 We use the **panelView** package to visualize the treatment and outcome variables:

--- a/vignettes/03-ife-mc.Rmd
+++ b/vignettes/03-ife-mc.Rmd
@@ -1,9 +1,13 @@
 # Factor-Based Methods {#sec-ife-mc}
 
+```{r .common, include = FALSE}
+source("_common.R")
+```
+
 ```{r setup-ife-mc, echo = FALSE, message = FALSE, warning = FALSE}
 set.seed(1234)
 library(fect)
-if (dir.exists("../data")) load("../data/fect.RData") else data(fect)
+data(fect)
 ```
 
 When the parallel trends assumption is violated due to latent common factors with heterogeneous loadings, the FE estimator from [Chapter @sec-fect] is biased. This chapter introduces two methods that account for such latent factors: the **interactive fixed effects** (IFE) method, which explicitly models unit-specific factor loadings, and the **matrix completion** (MC) method, which uses nuclear-norm regularization to recover the low-rank structure of the untreated potential outcomes. R script used in this chapter can be downloaded [here](https://raw.githubusercontent.com/xuyiqing/fect/dev/vignettes/rscript/03-ife-mc.R).

--- a/vignettes/04-cfe.Rmd
+++ b/vignettes/04-cfe.Rmd
@@ -4,21 +4,20 @@ The **Complex Fixed Effects (CFE)** estimator extends the standard two-way fixed
 
 In [Chapter @sec-ife-mc], we introduced factor-based methods (IFE and MC) that model latent common factors. CFE generalizes this framework by allowing researchers to incorporate additional observed structure alongside latent factors.
 
+```{r .common, include = FALSE}
+source("_common.R")
+```
+
 ```{r setup-cfe, echo = FALSE}
 set.seed(1234)
-rm(list = ls())
 ```
 
 ```{r load-packages-cfe, message = FALSE, warning = FALSE}
 library(fect)
-if (dir.exists("../data")) {
-  load("../data/fect.RData")
-  load("../data/sim_region.rda")
-  load("../data/sim_linear.rda")
-  load("../data/sim_trend.rda")
-} else {
-  data(fect); data(sim_region); data(sim_linear); data(sim_trend)
-}
+data(fect)
+data(sim_region)
+data(sim_linear)
+data(sim_trend)
 ```
 
 ------------------------------------------------------------------------

--- a/vignettes/05-hte.Rmd
+++ b/vignettes/05-hte.Rmd
@@ -1,14 +1,14 @@
 # Effect Heterogeneity {#sec-hte}
 
+```{r .common, include = FALSE}
+source("_common.R")
+```
+
 ```{r setup-hte, echo = FALSE, message = FALSE, warning = FALSE}
 set.seed(1234)
 library(fect)
-if (dir.exists("../data")) {
-  load("../data/fect.RData")
-  load("../data/sim_base.rda")
-} else {
-  data(fect); data(sim_base)
-}
+data(fect)
+data(sim_base)
 ```
 
 We provide several methods for researchers to explore heterogeneous treatment effects (HTE). These methods help distinguish between *effect modification* --- how the treatment effect varies across subpopulations --- and *causal moderation* --- whether changing the moderator causally alters the treatment effect. This chapter demonstrates both descriptive HTE tools and the formal causal moderation framework. R script used in this chapter can be downloaded [here](https://raw.githubusercontent.com/xuyiqing/fect/dev/vignettes/rscript/05-hte.R).

--- a/vignettes/06-plots.Rmd
+++ b/vignettes/06-plots.Rmd
@@ -1,5 +1,9 @@
 # Plot Options {#sec-plots}
 
+```{r .common, include = FALSE}
+source("_common.R")
+```
+
 In this chapter, we explore visualization options available in the **fect** package. Plots are organized by `type`:
 
 - the event study plot (`gap`)
@@ -23,7 +27,7 @@ We use two datasets throughout. @GS2020 examines the mobilizing effect of minori
 library(ggplot2)
 library(panelView)
 library(fect)
-if (dir.exists("../data")) load("../data/fect.RData") else data(fect)
+data(fect)
 ls()
 ```
 

--- a/vignettes/07-gsynth.Rmd
+++ b/vignettes/07-gsynth.Rmd
@@ -1,5 +1,9 @@
 # Gsynth Program {#sec-gsynth}
 
+```{r .common, include = FALSE}
+source("_common.R")
+```
+
 This chapter demonstrates the generalized synthetic control method, or Gsynth, proposed in @Xu2017 \[<a href="https://www.cambridge.org/core/journals/political-analysis/article/generalized-synthetic-control-method-causal-inference-with-interactive-fixed-effects-models/B63A8BD7C239DD4141C67DA10CD0E4F3" target="_blank">Paper</a>\].
 
 Gsynth was originally implemented in the **gsynth** package but has now been fully integrated into the **fect** package. Gsynth (`method = "gsynth"`) and FEct/IFEct/MC (`method = "fe"/"ife"/"mc"`) are different in the following ways:
@@ -30,17 +34,12 @@ We will use two datasets, `sim_gsynth` and `turnout`, to perform analyses in blo
 
 ```{r setup-seed, echo = FALSE}
 set.seed(1234)
-rm(list = ls())
 ```
 
 ```{r load-packages, warning=FALSE, message=FALSE}
 library(fect)
-if (dir.exists("../data")) {
-  load("../data/fect.RData")
-  load("../data/sim_gsynth.rda")
-} else {
-  data(fect); data(sim_gsynth)
-}
+data(fect)
+data(sim_gsynth)
 ls()
 ```
 

--- a/vignettes/08-panel.Rmd
+++ b/vignettes/08-panel.Rmd
@@ -6,6 +6,10 @@ editor:
 
 # Modern DID Methods {#sec-panel}
 
+```{r .common, include = FALSE}
+source("_common.R")
+```
+
 This chapter, authored by Ziyi Liu and Yiqing Xu, complements @CLLX2025 ([paper](https://yiqingxu.org/papers/english/2023_panel/CLLX.pdf), [slides](https://yiqingxu.org/papers/english/2023_panel/CLLX_slides.pdf)).
 Rivka Lipkovitz also contributes to this tutorial. R script used in this chapter can be downloaded [here](https://raw.githubusercontent.com/xuyiqing/fect/dev/vignettes/rscript/08-panel.R).
 
@@ -76,7 +80,7 @@ We begin with an empirical example from @HH2019, who investigate the effects of 
 The study finds that switching from direct to indirect democracy increased naturalization rates by an average of 1.22 percentage points (Model 1, Table 1).
 
 ```{r load-hh2019, message = FALSE, warning = FALSE}
-if (dir.exists("../data")) load("../data/fect.RData") else data(fect)
+data(fect)
 data <- hh2019
 head(data)
 ```
@@ -674,7 +678,7 @@ House general elections between 1980 and 2012, arguing that the presence of Asia
 Here, we focus specifically on the effects of Asian candidates, as shown in the top left panel of Figure 5 in the paper.
 
 ```{r load-gs2020, message = FALSE, warning = FALSE}
-if (dir.exists("../data")) load("../data/fect.RData") else data(fect)
+data(fect)
 data <- gs2020
 data$cycle <- as.integer(as.numeric(data$cycle/2))
 head(data)

--- a/vignettes/09-sens.Rmd
+++ b/vignettes/09-sens.Rmd
@@ -1,5 +1,8 @@
 # Sensitivity Analysis {#sec-panel-sens}
 
+```{r .common, include = FALSE}
+source("_common.R")
+```
 
 ------------------------------------------------------------------------
 
@@ -44,7 +47,7 @@ library(HonestDiDFEct) # Required for fect_sens to work
 We begin with an empirical example from @HH2019, who investigate the effects of indirect democracy versus direct democracy on naturalization rates in Switzerland using municipality-year panel data from 1991 to 2009. The study finds that switching from direct to indirect democracy increased naturalization rates by an average of 1.22 percentage points (Model 1, Table 1).
 
 ```{r load-hh2019, message = FALSE, warning = FALSE}
-if (dir.exists("../data")) load("../data/fect.RData") else data(fect)
+data(fect)
 data <- hh2019
 head(data)
 ```

--- a/vignettes/_common.R
+++ b/vignettes/_common.R
@@ -1,0 +1,11 @@
+# Shared setup for all vignette chapters
+# When rendering locally from the source tree, devtools::load_all()
+# ensures the LATEST R functions (including new features like cm) and
+# all datasets are available, even if the installed package is outdated.
+# During R CMD check the package is freshly installed, so library() suffices.
+if (file.exists("../DESCRIPTION") &&
+    requireNamespace("devtools", quietly = TRUE)) {
+  suppressMessages(devtools::load_all("..", quiet = TRUE))
+} else {
+  suppressMessages(library(fect))
+}


### PR DESCRIPTION
Local quarto render uses the installed fect package, which may be outdated and lack new features (e.g., cm parameter). Added _common.R that calls devtools::load_all() when rendering from the source tree, ensuring all R functions and lazy-loaded datasets come from the latest source code. Falls back to library(fect) for R CMD check.

Also reverted data loading to clean data() calls (load_all handles everything) and fixed fect.Rd line width exceeding 90 chars.

https://claude.ai/code/session_014ctjR27HYMWhCzsP5jesLW