### PR TITLE
fix: add eff/D/I/boot.id to ALL boot0 fallback lists in fect_boot

### DIFF
--- a/R/boot.R
+++ b/R/boot.R
@@ -712,7 +712,11 @@ fect_boot <- function(
           att.carryover.W = NA,
           balance.avg.att = NA,
           balance.time = NA,
-          group.output = list()
+          group.output = list(),
+          eff = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+          D = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+          I = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+          boot.id = NULL
         )
         return(boot0)
       } else {
@@ -1112,7 +1116,11 @@ fect_boot <- function(
           count.off.W = NA,
           time.off.W = NA,
           att.carryover.W = NA,
-          group.output = list()
+          group.output = list(),
+          eff = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+          D = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+          I = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+          boot.id = NULL
         )
         return(boot0)
       } else {
@@ -1275,7 +1283,11 @@ fect_boot <- function(
           count.off.W = NA,
           time.off.W = NA,
           att.carryover.W = NA,
-          group.output = list()
+          group.output = list(),
+          eff = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+          D = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+          I = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+          boot.id = NULL
         )
         return(boot0)
       } else {
@@ -1642,7 +1654,11 @@ fect_boot <- function(
             att.off.W = NA,
             count.off.W = NA,
             time.off.W = NA,
-            att.carryover.W = NA
+            att.carryover.W = NA,
+            eff = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+            D = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+            I = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
+            boot.id = NULL
           )
           return(boot0)
         } else {


### PR DESCRIPTION
The previous fix only patched the degenerate D/I early-return boot0. The try-error fallback boot0 in one.nonpara (and parametric bootstrap functions) was also missing these fields, causing dimension mismatch when keep.sims=TRUE and any bootstrap iteration fails with try-error.

https://claude.ai/code/session_014ctjR27HYMWhCzsP5jesLW