### PR TITLE
fix: trim eff.boot/D.boot/I.boot when removing failed bootstrap itera…

### DIFF
--- a/R/boot.R
+++ b/R/boot.R
@@ -2178,6 +2178,12 @@ fect_boot <- function(
         }
       }
     }
+    if (keep.sims) {
+      eff.boot <- eff.boot[, , -boot.rm, drop = FALSE]
+      D.boot <- D.boot[, , -boot.rm, drop = FALSE]
+      I.boot <- I.boot[, , -boot.rm, drop = FALSE]
+      colnames.boot <- colnames.boot[-boot.rm]
+    }
   }
   if (dis) {
     message(dim(att.boot)[2], " runs\n", sep = "")


### PR DESCRIPTION
…tions

When boot.rm removes failed iterations, the 2D matrices (att.boot etc.) were trimmed but the 3D arrays (eff.boot, D.boot, I.boot) used by keep.sims were not. This caused subscript out of bounds in effect() which uses length(att.avg.boot) as nboots but indexes into the untrimmed 3D arrays.

https://claude.ai/code/session_014ctjR27HYMWhCzsP5jesLW