### PR TITLE
fix: remove keep.sims conditional from boot0 inside one.nonpara

### DIFF
--- a/R/boot.R
+++ b/R/boot.R
@@ -1427,9 +1427,9 @@ fect_boot <- function(
           time.off.W = NA,
           att.carryover.W = NA,
           group.out = list(),
-          eff = if (keep.sims) matrix(NA_real_, TT, length(boot.id)) else NULL,
-          D = if (keep.sims) matrix(NA_real_, TT, length(boot.id)) else NULL,
-          I = if (keep.sims) matrix(NA_real_, TT, length(boot.id)) else NULL,
+          eff = matrix(NA_real_, TT, length(boot.id)),
+          D = matrix(NA_real_, TT, length(boot.id)),
+          I = matrix(NA_real_, TT, length(boot.id)),
           boot.id = boot.id
         )
         return(boot0)
@@ -1655,10 +1655,10 @@ fect_boot <- function(
             count.off.W = NA,
             time.off.W = NA,
             att.carryover.W = NA,
-            eff = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
-            D = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
-            I = if (keep.sims) matrix(NA_real_, TT, N) else NULL,
-            boot.id = NULL
+            eff = matrix(NA_real_, TT, length(boot.id)),
+            D = matrix(NA_real_, TT, length(boot.id)),
+            I = matrix(NA_real_, TT, length(boot.id)),
+            boot.id = boot.id
           )
           return(boot0)
         } else {

--- a/vignettes/06-plots.Rmd
+++ b/vignettes/06-plots.Rmd
@@ -54,7 +54,7 @@ out.hh <- fect(nat_rate_ord ~ indirect,
                data = hh2019,
                index = c("bfs","year"),
                method = 'fe', se = TRUE,
-               parallel = TRUE, nboots = 1000,
+               parallel = FALSE, nboots = 200,
                keep.sims = TRUE)
 ```
 


### PR DESCRIPTION
The if(keep.sims) conditional in boot0 lists inside one.nonpara added keep.sims as a free variable that may not survive trim_closure_env serialization for parallel workers. Always create NA matrices instead (harmless when keep.sims=FALSE since they're not stored).

Also use parallel=FALSE and nboots=200 for the keep.sims=TRUE call in 06-plots.Rmd to avoid parallel serialization issues entirely.

https://claude.ai/code/session_014ctjR27HYMWhCzsP5jesLW