### PR TITLE
fix: use parallel=FALSE for second keep.sims=TRUE call in 06-plots.Rmd

### DIFF
--- a/vignettes/06-plots.Rmd
+++ b/vignettes/06-plots.Rmd
@@ -391,8 +391,8 @@ out_no_reversals <- fect(Y = "general_sharetotal_A_all",
                          data = gs2020_no_reversals,
                          method = "fe",
                          force =  "two-way",
-                         se = TRUE, parallel = TRUE,
-                         nboots = 100,
+                         se = TRUE, parallel = FALSE,
+                         nboots = 200,
                          keep.sims = TRUE)
 ```
 


### PR DESCRIPTION
The out_no_reversals fect() call also used parallel=TRUE with keep.sims=TRUE, hitting the same parallel serialization issue. Switch to parallel=FALSE, nboots=200 to match the out.hh fix.

https://claude.ai/code/session_014ctjR27HYMWhCzsP5jesLW