### PR TITLE
fix: set parallel=FALSE in all vignette fect() calls

### DIFF
--- a/vignettes/02-fect.Rmd
+++ b/vignettes/02-fect.Rmd
@@ -97,7 +97,7 @@ The key parameters that control **uncertainty estimation** are: `se` (enable sta
 ```{r simdata_fect, eval=TRUE, cache = TRUE, message = FALSE, results = 'hide'}
 out.fect <- fect(Y ~ D + X1 + X2, data = sim_base, index = c("id","time"),
   method = "fe", force = "two-way", se = TRUE,
-  cores = 8, parallel = TRUE, nboots = 1000)
+  parallel = FALSE, nboots = 1000)
 ```
 
 The `plot()` function can visualize the estimated period-wise ATTs as well as their uncertainty estimates. `stats = "F.p"` shows the p-value for the F test of no-pretrend.
@@ -152,7 +152,7 @@ We provide a placebo test for a settled model by setting `placeboTest = TRUE`. W
 ```{r fect_placebo, eval=TRUE, cache=TRUE, message=FALSE, results='hide', fig.width=6, fig.height=4.5}
 out.fect.placebo <- fect(Y ~ D + X1 + X2, data = sim_base, index = c("id","time"),
   force = "two-way", method = "fe",
-  se = TRUE, cores = 8, nboots = 200, parallel = TRUE,
+  se = TRUE, nboots = 200, parallel = FALSE,
   placeboTest = TRUE, placebo.period = c(-2, 0))
 plot(out.fect.placebo, cex.text = 0.8)
 ```
@@ -168,7 +168,7 @@ To perform the carryover test, we set `carryoverTest = TRUE` and specify the ran
 ```{r fect_carryover, eval=TRUE, cache=TRUE, message=FALSE, results='hide'}
 out.fect.carry <- fect(Y ~ D + X1 + X2, data = sim_base, index = c("id","time"),
   force = "two-way", method = "fe",
-  se = TRUE, cores = 8, nboots = 200, parallel = TRUE,
+  se = TRUE, nboots = 200, parallel = FALSE,
   carryoverTest = TRUE, carryover.period = c(1, 3))
 ```
 
@@ -193,7 +193,7 @@ We can implement the leave-one-out pre-trend test by setting `loo = TRUE`.
 ```{r fect_loo, eval=TRUE, cache = TRUE, message = FALSE}
 out.fect.loo <- fect(Y ~ D + X1 + X2, data = sim_base, index = c("id","time"),
   method = "fe", force = "two-way", se = TRUE, loo = TRUE,
-  cores = 8, parallel = TRUE, nboots = 200)
+  parallel = FALSE, nboots = 200)
 ```
 
 The event study plot utilizing leave-one-out for pretreatment estimates is shown below. This graph is fairly similar to the graphics we presented earlier without using leave-one-out. However, this is not always true.
@@ -274,7 +274,7 @@ After obtaining the individual treatment effects using one of the counterfactual
 ```{r simdata_bal, eval=TRUE, cache = TRUE}
 out.bal <- fect(Y ~ D + X1 + X2, data = sim_base, index = c("id","time"),
   balance.period = c(-3, 4), force = "two-way", method = "ife",
-  CV = FALSE, r = 2, se = TRUE, nboots = 200, parallel = TRUE)
+  CV = FALSE, r = 2, se = TRUE, nboots = 200, parallel = FALSE)
 ```
 
 We can then visualize the dynamic treatment effects using the inbuilt function `plot`. By default, it displays the dynamic treatment effects of the "balanced" sample.
@@ -320,7 +320,7 @@ By setting the option `group = "Cohort"`, **fect** estimates the ATT for each sp
 ```{r simdata_fe_cohort, eval = TRUE, cache = TRUE, message = FALSE, results='hide'}
 out.fe.g <- fect(Y ~ D + X1 + X2, data = sim_base.cohort, index = c("id","time"),
           force = "two-way", method = "fe",
-          se = TRUE, nboots = 200, parallel = TRUE, group = 'Cohort')
+          se = TRUE, nboots = 200, parallel = FALSE, group = 'Cohort')
 ```
 
 Then one can draw the gap plot for each sub-group. Here we present the gap plot for Cohort 22.
@@ -338,7 +338,7 @@ The package offers the option `W` to calculate the weighted average treatment ef
 sim_base$Weight <- abs(rnorm(n = dim(sim_base)[1]))
 out.w <- fect(Y ~ D + X1 + X2, data = sim_base, index = c("id","time"),
   force = "two-way", method = "ife", W = 'Weight',
-  CV = FALSE, r = 2, se = TRUE, nboots = 200, parallel = TRUE)
+  CV = FALSE, r = 2, se = TRUE, nboots = 200, parallel = FALSE)
 ```
 
 We can then visualize the weighted dynamic treatment effects using the inbuilt function `plot`, it by default shows the weighted dynamic treatment effects.

--- a/vignettes/03-ife-mc.Rmd
+++ b/vignettes/03-ife-mc.Rmd
@@ -24,7 +24,7 @@ We specify an interval of candidate number of unobserved factors in option `r` l
 ```{r simdata_ife, eval=TRUE, cache = TRUE}
 out.ife <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id","time"),
           force = "two-way", method = "ife", CV = TRUE, r = c(0, 5),
-          se = TRUE, cores = 8, nboots = 1000, parallel = TRUE)
+          se = TRUE, nboots = 1000, parallel = FALSE)
 print(out.ife)
 ```
 
@@ -43,7 +43,7 @@ For the MC method, we need to specify the tuning parameter in the penalty term u
 ```{r simdata_mc, eval=TRUE, cache = TRUE}
 out.mc <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id","time"),
           force = "two-way", method = "mc", CV = TRUE,
-          se = TRUE, cores = 8, nboots = 1000, parallel = TRUE)
+          se = TRUE, nboots = 1000, parallel = FALSE)
 
 print(out.mc)
 ```
@@ -67,7 +67,7 @@ When using `method = "ife"` or `method = "mc"`, we need to choose a tuning param
 ```{r cv_ife_demo, eval=TRUE, cache=TRUE, message=FALSE, results='hide'}
 out.cv <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id","time"),
                method = "ife", CV = TRUE, r = c(0, 5),
-               se = FALSE, parallel = TRUE)
+               se = FALSE, parallel = FALSE)
 ```
 
 ```{r print-cv-selected-r}
@@ -94,11 +94,11 @@ We provide an example below.
 ```{r cv_method_compare, eval=TRUE, cache=TRUE, message=FALSE, results='hide'}
 out.all <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id","time"),
                 method = "ife", CV = TRUE, r = c(0, 5),
-                cv.method = "all_units", se = FALSE, parallel = TRUE)
+                cv.method = "all_units", se = FALSE, parallel = FALSE)
 
 out.tr <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id","time"),
                method = "ife", CV = TRUE, r = c(0, 5),
-               cv.method = "treated_units", se = FALSE, parallel = TRUE)
+               cv.method = "treated_units", se = FALSE, parallel = FALSE)
 ```
 
 ```{r print-cv-method-compare}
@@ -136,11 +136,11 @@ The `criterion` parameter determines which scoring metric is used to select the 
 ```{r criterion_compare, eval=TRUE, cache=TRUE, message=FALSE, results='hide'}
 out.mspe <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id","time"),
                  method = "ife", CV = TRUE, r = c(0, 5),
-                 criterion = "mspe", se = FALSE, parallel = TRUE)
+                 criterion = "mspe", se = FALSE, parallel = FALSE)
 
 out.pc <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id","time"),
                method = "ife", CV = TRUE, r = c(0, 5),
-               criterion = "gmspe", se = FALSE, parallel = TRUE)
+               criterion = "gmspe", se = FALSE, parallel = FALSE)
 ```
 
 ```{r print-criterion-compare}
@@ -156,7 +156,7 @@ A candidate `r` is selected over a smaller value only if its criterion score imp
 
 ### Parallel computing
 
-Cross-validation can be computationally expensive, especially with `cv.method = "all_units"` in the nevertreated setting (which re-estimates the full factor model `k` times per candidate `r`). Parallel computing is enabled by default when `parallel = TRUE` in `fect()`.
+Cross-validation can be computationally expensive, especially with `cv.method = "all_units"` in the nevertreated setting (which re-estimates the full factor model `k` times per candidate `r`). Parallel computing can be enabled by setting `parallel = TRUE` in `fect()`.
 
 For the nevertreated path, parallel CV auto-activates when the panel is large enough ($N_{co} \times T > 20{,}000$) and `cv.method = "all_units"`. The `"treated_units"` and `"loo"` methods are always sequential because the per-fold cost is too low to benefit from parallelization overhead.
 
@@ -173,12 +173,12 @@ We provide a placebo test for a settled model---hence, cross-validation is not a
 ```{r placebo_ife, eval = TRUE, cache = TRUE, message = FALSE, results='hide'}
 out.ife.p <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id", "time"),
   force = "two-way", method = "ife",  r = 2, CV = 0,
-  parallel = TRUE, se = TRUE,
+  parallel = FALSE, se = TRUE,
   nboots = 200, placeboTest = TRUE, placebo.period = c(-2, 0))
 
 out.mc.p <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id", "time"),
   force = "two-way", method = "mc",  lambda = out.mc$lambda.cv,
-  CV = 0, parallel = TRUE, se = TRUE,
+  CV = 0, parallel = FALSE, se = TRUE,
   nboots = 200, placeboTest = TRUE, placebo.period = c(-2, 0))
 ```
 
@@ -208,9 +208,9 @@ Instead of using estimated ATTs for periods prior to the treatment to test for p
 
 ```{r simdata_ife_loo, eval=TRUE, cache = TRUE, message = FALSE, results = 'hide'}
 out.ife.loo <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id","time"),
-  method = "ife", force = "two-way", se = TRUE, parallel = TRUE, cores = 8, nboots = 200, loo = TRUE)
+  method = "ife", force = "two-way", se = TRUE, parallel = FALSE, nboots = 200, loo = TRUE)
 out.mc.loo <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id","time"),
-  method = "mc", force = "two-way", se = TRUE, parallel = TRUE, cores = 8, nboots = 200, loo = TRUE)
+  method = "mc", force = "two-way", se = TRUE, parallel = FALSE, nboots = 200, loo = TRUE)
 ```
 
 After the LOO estimation, one can plot these LOO pre-trends in the gap plot or the equivalence plot by setting `loo = TRUE` in the `plot` function. Since all pre-treatment estimates are now out-of-sample, the plot uses a uniform black color for all points (no gray/black distinction). The equivalence plots below use the LOO estimates directly.
@@ -254,12 +254,12 @@ Below, we set `carryover.period = c(1, 3)`. As we deduct the treatment effect fr
 ```{r carryover_ife, eval = TRUE, cache = TRUE, message = FALSE, results='hide'}
 out.ife.c <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id", "time"),
   force = "two-way", method = "ife", r = 2, CV = 0,
-  parallel = TRUE, se = TRUE,
+  parallel = FALSE, se = TRUE,
   nboots = 200, carryoverTest = TRUE, carryover.period = c(1, 3))
 
 out.mc.c <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id", "time"),
   force = "two-way", method = "mc",  lambda = out.mc$lambda.cv,
-  CV = 0, parallel = TRUE, se = TRUE,
+  CV = 0, parallel = FALSE, se = TRUE,
   nboots = 200, carryoverTest = TRUE, carryover.period = c(1, 3))
 ```
 
@@ -282,7 +282,7 @@ Using real-world data, researchers will likely find that carryover effects exist
 ```{r carryover_rm, eval = TRUE, cache = TRUE, message = FALSE, results='hide', fig.width = 6, fig.height = 4.5}
 out.ife.rm.test <- fect(Y ~ D + X1 + X2, data = simdata, index = c("id", "time"),
   force = "two-way", method = "ife", r = 2, CV = 0,
-  parallel = TRUE, se = TRUE,  carryover.rm = 3,
+  parallel = FALSE, se = TRUE,  carryover.rm = 3,
   nboots = 200, carryoverTest = TRUE, carryover.period = c(1, 3))# remove three periods
 
 plot(out.ife.rm.test, cex.text = 0.8, stats.pos = c(5, 2.5))

--- a/vignettes/04-cfe.Rmd
+++ b/vignettes/04-cfe.Rmd
@@ -102,7 +102,7 @@ We first try the standard FE estimator, which ignores the region-level shocks:
 out.fe.only <- fect(Y ~ D, data = sim_region,
   index = c("id", "time"),
   method = "fe", force = "two-way",
-  se = TRUE, parallel = TRUE, nboots = 200,
+  se = TRUE, parallel = FALSE, nboots = 200,
   placeboTest = TRUE, placebo.period = c(-2, 0))
 ```
 
@@ -123,7 +123,7 @@ Now we interact region with time to create group×period fixed effects, which ab
 out.cfe.region <- fect(Y ~ D, data = sim_region,
   index = c("id", "time", "region_time"),
   method = "cfe", force = "two-way",
-  se = TRUE, parallel = TRUE, nboots = 200,
+  se = TRUE, parallel = FALSE, nboots = 200,
   placeboTest = TRUE, placebo.period = c(-2, 0))
 ```
 
@@ -156,7 +156,7 @@ First, we estimate the FE model, which ignores the interactive structure entirel
 out.fe.base <- fect(Y ~ D + X1 + X2, data = simdata,
   index = c("id", "time"),
   method = "fe", force = "two-way",
-  se = TRUE, parallel = TRUE, nboots = 200,
+  se = TRUE, parallel = FALSE, nboots = 200,
   placeboTest = TRUE, placebo.period = c(-2, 0))
 ```
 
@@ -178,7 +178,7 @@ out.cfe.z <- fect(Y ~ D + X1 + X2, data = simdata,
   index = c("id", "time"),
   method = "cfe", force = "two-way",
   Z = "L1", gamma = "gamma_t",
-  se = TRUE, parallel = TRUE, nboots = 200,
+  se = TRUE, parallel = FALSE, nboots = 200,
   placeboTest = TRUE, placebo.period = c(-2, 0))
 ```
 
@@ -217,7 +217,7 @@ Without accounting for the unit-specific linear trends, the FE estimator fails t
 out.fe.lin <- fect(Y ~ D, data = sim_linear,
   index = c("id", "time"),
   method = "fe", force = "two-way",
-  se = TRUE, parallel = TRUE, nboots = 200,
+  se = TRUE, parallel = FALSE, nboots = 200,
   placeboTest = TRUE, placebo.period = c(-2, 0))
 ```
 
@@ -235,7 +235,7 @@ out.cfe.lin <- fect(Y ~ D, data = sim_linear,
   index = c("id", "time"),
   method = "cfe", force = "two-way",
   Q.type = "linear",
-  se = TRUE, parallel = TRUE, nboots = 200,
+  se = TRUE, parallel = FALSE, nboots = 200,
   placeboTest = TRUE, placebo.period = c(-2, 0))
 ```
 
@@ -264,7 +264,7 @@ The FE estimator fails the placebo test because it cannot capture the nonlinear 
 out.fe.trend <- fect(Y ~ D, data = sim_trend,
   index = c("id", "time"),
   method = "fe", force = "two-way",
-  se = TRUE, parallel = TRUE, nboots = 200,
+  se = TRUE, parallel = FALSE, nboots = 200,
   placeboTest = TRUE, placebo.period = c(-2, 0))
 ```
 
@@ -282,7 +282,7 @@ out.cfe.bs <- fect(Y ~ D, data = sim_trend,
   index = c("id", "time"),
   method = "cfe", force = "two-way",
   Q.type = "bspline",
-  se = TRUE, parallel = TRUE, nboots = 200,
+  se = TRUE, parallel = FALSE, nboots = 200,
   placeboTest = TRUE, placebo.period = c(-2, 0))
 ```
 
@@ -367,7 +367,7 @@ out.cfe.best <- fect(Y ~ D + X1 + X2, data = simdata,
   method = "cfe", force = "two-way",
   Z = "L1", gamma = "gamma_t",
   r = 1,
-  se = TRUE, parallel = TRUE, nboots = 200,
+  se = TRUE, parallel = FALSE, nboots = 200,
   placeboTest = TRUE, placebo.period = c(-2, 0))
 ```
 

--- a/vignettes/05-hte.Rmd
+++ b/vignettes/05-hte.Rmd
@@ -18,7 +18,7 @@ We start with descriptive tools using `sim_base`. These work with any estimation
 ```{r hte_setup, eval=TRUE, cache=TRUE, message=FALSE, results='hide'}
 out.fect <- fect(Y ~ D + X1 + X2, data = sim_base, index = c("id","time"),
   method = "fe", force = "two-way", se = TRUE,
-  cores = 8, parallel = TRUE, nboots = 200)
+  parallel = FALSE, nboots = 200)
 ```
 
 ### Box plot
@@ -51,7 +51,7 @@ We can also plot the CATT when a covariate is discrete. To demonstrate this, we 
 sim_base$X3 <- sample(1:3, size = nrow(sim_base), replace = TRUE)
 out.fect.X3 <- fect(Y ~ D + X1 + X2 + X3, data = sim_base, index = c("id","time"),
                    method = "fe", se = TRUE, seed = 123,
-                   cores = 8, nboots = 200, parallel = TRUE)
+                   nboots = 200, parallel = FALSE)
 ```
 
 As expected, there is not much effect heterogeneity along `X3`. In the resulting figure, we can also assign labels to the discrete values in the moderator.
@@ -83,7 +83,7 @@ Currently `cm` is available for the `"fe"` and `"ife"` methods.
 ```{r cm_fe, eval = TRUE, cache = TRUE, message = FALSE, results = 'hide'}
 out.cm <- fect(Y ~ D + X1 + X2, data = sim_base, index = c("id", "time"),
                method = "fe", force = "two-way", se = TRUE,
-               cm = TRUE, parallel = TRUE, cores = 8, nboots = 200)
+               cm = TRUE, parallel = FALSE, nboots = 200)
 ```
 
 ### Effect modification vs. causal moderation
@@ -192,7 +192,7 @@ sim_base$X3 <- sample(1:3, size = nrow(sim_base), replace = TRUE)
 out.discrete <- fect(Y ~ D + X1 + X2 + X3, data = sim_base,
                      index = c("id", "time"),
                      method = "fe", force = "two-way", se = TRUE,
-                     cm = TRUE, parallel = TRUE, cores = 8, nboots = 200)
+                     cm = TRUE, parallel = FALSE, nboots = 200)
 ```
 
 ```{r discrete_em_plot, eval = TRUE, cache = TRUE, warning = FALSE, fig.width = 6, fig.height = 4.5}

--- a/vignettes/06-plots.Rmd
+++ b/vignettes/06-plots.Rmd
@@ -48,7 +48,7 @@ out <- fect(Y = "general_sharetotal_A_all",
             index = c("district_final", "cycle"),
             data = gs2020, method = "fe",
             force = "two-way", se = TRUE,
-            parallel = TRUE, nboots = 1000)
+            parallel = FALSE, nboots = 1000)
 
 out.hh <- fect(nat_rate_ord ~ indirect,
                data = hh2019,
@@ -270,7 +270,7 @@ A placebo test artificially assigns treatment during pre-treatment periods and e
 ```{r placebo, cache = TRUE}
 out_fe_placebo <- fect(Y = "general_sharetotal_A_all", D = "cand_A_all", X = c("cand_H_all", "cand_B_all"), data = gs2020,
                        index = c("district_final", "cycle"), force = "two-way",
-                       method = "fe", CV = FALSE, parallel = TRUE,
+                       method = "fe", CV = FALSE, parallel = FALSE,
                        se = TRUE, nboots = 1000, placeboTest = TRUE,
                        placebo.period = c(-2, 0))
 
@@ -346,7 +346,7 @@ The carryover test examines whether the treatment effect persists after treatmen
 ```{r carryover, cache = TRUE}
 out_fe_carryover <- fect(Y = "general_sharetotal_A_all", D = "cand_A_all", X = c("cand_H_all", "cand_B_all"), data = gs2020,
                        index = c("district_final", "cycle"), force = "two-way",
-                         parallel = TRUE, se = TRUE, CV = FALSE,
+                         parallel = FALSE, se = TRUE, CV = FALSE,
                          nboots = 1000, carryoverTest = TRUE,
                          carryover.period = c(1, 3))
 plot(out_fe_carryover)
@@ -475,7 +475,7 @@ out_ife <- fect(nat_rate_ord ~ indirect,
                 data = hh2019,
                 index = c("bfs", "year"),
                 method = "ife", r = 2,
-                se = TRUE, parallel = TRUE, nboots = 200)
+                se = TRUE, parallel = FALSE, nboots = 200)
 ```
 
 The **factors** plot displays the estimated latent time factors. It uses the Okabe-Ito colorblind-safe palette with thinner lines for a clean, publication-ready appearance. Factor 0 (fixed effects, shown when `include.FE = TRUE`) appears in gray; subsequent factors appear in orange, blue, green, and so on. Use `nfactors` to limit the number of displayed factors.

--- a/vignettes/07-gsynth.Rmd
+++ b/vignettes/07-gsynth.Rmd
@@ -110,18 +110,18 @@ Treatment effect estimates from each bootstrap run are stored in `att.boot`, an 
 
 ```{r sim2, cache = TRUE, warning = FALSE}
 system.time(
-out <- fect(Y ~ D + X1 + X2, data = sim_gsynth, index = c("id","time"), method = "gsynth", force = "two-way", CV = TRUE, r = c(0, 5), se = TRUE, nboots = 1000,vartype = 'parametric', parallel = TRUE, cores = 16)
+out <- fect(Y ~ D + X1 + X2, data = sim_gsynth, index = c("id","time"), method = "gsynth", force = "two-way", CV = TRUE, r = c(0, 5), se = TRUE, nboots = 200, vartype = 'parametric', parallel = FALSE)
 )
 ```
 
 Gsynth in **fect** also incorporates jackknife method for uncertainty estimates.
 
 ```{r simJack, cache = TRUE, message = FALSE}
-out2 <- fect(Y ~ D + X1 + X2, data = sim_gsynth,  index = c("id","time"), 
-               method = "gsynth", force = "two-way", 
+out2 <- fect(Y ~ D + X1 + X2, data = sim_gsynth,  index = c("id","time"),
+               method = "gsynth", force = "two-way",
                CV = TRUE, r = c(0, 5), se = TRUE,
-               vartype = "jackknife", 
-               parallel = TRUE, cores = 8)
+               vartype = "jackknife",
+               parallel = FALSE)
 
 ```
 
@@ -405,7 +405,7 @@ out_ub <- fect(turnout ~ policy_edr + policy_mail_in + policy_motor,
               data = turnout.ub,  index = c("abb","year"), 
               se = TRUE, method = "gsynth", 
               r = c(0, 5), CV = TRUE, force = "two-way", 
-              parallel = TRUE, min.T0 = 8, 
+              parallel = FALSE, min.T0 = 8,
               nboots = 1000, seed = 02139)
 ```
 
@@ -454,7 +454,7 @@ out.cfe.nt <- fect(Y ~ D + X1 + X2, data = sim_gsynth, index = c("id","time"),
                    time.component.from = "nevertreated",
                    Q.type = "linear",
                    se = FALSE, CV = TRUE, r = c(0, 5),
-                   parallel = TRUE)
+                   parallel = FALSE)
 ```
 
 ```{r cfe-nt-summary}

--- a/vignettes/08-panel.Rmd
+++ b/vignettes/08-panel.Rmd
@@ -840,7 +840,7 @@ Both are very close to the TWFE estimates.
 model.fect <- fect(Y = "general_sharetotal_A_all", D = "cand_A_all", 
                    X= c("cand_H_all", "cand_B_all"), data = data, 
                    method = "fe", index = index, se = TRUE, 
-                   parallel = TRUE, seed = 1234, force = "two-way")
+                   parallel = FALSE, seed = 1234, force = "two-way")
 
 print(model.fect$est.avg)
 ```

--- a/vignettes/09-sens.Rmd
+++ b/vignettes/09-sens.Rmd
@@ -86,7 +86,7 @@ out.fect.placebo <- fect_sens(
   periodMbarvec = Mbar_vec_period_rm,
   Mvec          = M_vec_avg_smooth,
   periodMvec    = M_vec_period_smooth,
-  parallel      = TRUE # Set to TRUE for parallel processing if desired
+  parallel      = FALSE # Set to TRUE for parallel processing if desired
 )
 ```
 


### PR DESCRIPTION
When rendering locally with devtools::load_all(), parallel workers load the installed (old) fect package via .packages=c("fect",...), causing version mismatches between source R functions and installed internal helpers. This makes all parallel bootstrap/jackknife iterations fail. Use parallel=FALSE for all vignette rendering.