### PR TITLE
Make polars/DIDmultiplegtDYN conditional in 08-panel.Rmd

### DIFF
--- a/vignettes/08-panel.Rmd
+++ b/vignettes/08-panel.Rmd
@@ -68,8 +68,11 @@ library(didimputation)
 library(doParallel)
 library(HonestDiD)
 library(HonestDiDFEct)
-library(polars)
-library(DIDmultiplegtDYN) # requires polars; may require XQuartz for rgl
+has_polars <- requireNamespace("polars", quietly = TRUE)
+if (has_polars) {
+  library(polars)
+  library(DIDmultiplegtDYN) # requires polars; may require XQuartz for rgl
+}
 ```
 
 ## No Treatment Reversals
@@ -453,7 +456,7 @@ knitr::include_graphics("fig/fig_pm.png")
 
 In the following example, we set $l = 12$ and $k = 9$.
 
-```{r hh_didm, message = FALSE, warning = FALSE, fig.width = 6, fig.height = 4.5, cache=TRUE}
+```{r hh_didm, message = FALSE, warning = FALSE, fig.width = 6, fig.height = 4.5, cache=TRUE, eval=has_polars}
 didm.results <- did_multiplegt_dyn(
       df = df.use,
       outcome = "nat_rate_ord",
@@ -471,7 +474,7 @@ print(didm.results)
 
 Again, we make an event study plot using `esplot`.
 
-```{r hh_didm.dynamic, message = FALSE, warning = FALSE, fig.width = 7, fig.height = 5, cache=TRUE}
+```{r hh_didm.dynamic, message = FALSE, warning = FALSE, fig.width = 7, fig.height = 5, cache=TRUE, eval=has_polars}
 T.post <- dim(didm.results$results$Effects)[1]
 T.pre <- dim(didm.results$results$Placebos)[1]
 didm.vis <- rbind(didm.results$results$Placebos,didm.results$results$Effects)


### PR DESCRIPTION
polars is not available on CRAN and may not be installed. Wrap the library() calls in a requireNamespace check and gate the two didm chunks with eval=has_polars so the vignette renders even without polars.