### PR TITLE
Fix wrapper_boot chunk: disable parallel and reduce nboots

### DIFF
--- a/vignettes/08-panel.Rmd
+++ b/vignettes/08-panel.Rmd
@@ -959,7 +959,9 @@ res_st <- did_wrapper(
   D      = "indirect",
   index  = c("bfs", "year"),
   method = "st",
-  se     = "boot"
+  se     = "boot",
+  nboots = 50,
+  parallel = FALSE
 )
 print(res_st)
 ```


### PR DESCRIPTION
The MultisessionFuture was getting interrupted during vignette rendering due to resource constraints. Set parallel=FALSE and nboots=50 to avoid the issue while still demonstrating the bootstrap SE functionality.