### PR TITLE
fix: preserve method after CV when r.cv = 0 (gsynth/cfe boot crash)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,6 @@
 ^architecture\.md$
 ^log$
 ^data-raw$
+^cell-D1\.rds$
+^fect_.*\.tar\.gz$
+^fect\.Rcheck$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: fect
 Type: Package
 Title: Fixed Effects Counterfactual Estimators
-Version: 2.2.0
-Date: 2026-03-20
+Version: 2.2.1
+Date: 2026-04-21
 Authors@R: 
     c(person("Licheng", "Liu", , "lichengl@stanford.edu", role = c("aut")), 
       person("Ziyi", "Liu", , "zyliu2023@berkeley.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# fect 2.2.1
+
+* Fixed `Unsupported bootstrap method: fe` crash when `fect(method = "gsynth", CV = TRUE, se = TRUE, ...)` (or `method = "cfe"`) selected `r.cv = 0` via cross-validation. `fect_nevertreated()` used to relabel its outgoing `$method` to `"fe"` in that case, and `fect_boot()`'s per-iteration dispatcher had no `"fe"` branch. The fix keeps `$method` as `"gsynth"` (or `"cfe"`); the existing dispatcher branches already handle `r = 0` correctly. Reported against the `gsynth` wrapper, which delegates SE to fect.
+
 # fect 2.2.0
 
 * Added CFE (Complex Fixed Effects) estimator (`method = "cfe"`)

--- a/R/fect_nevertreated.R
+++ b/R/fect_nevertreated.R
@@ -2844,10 +2844,15 @@ fect_nevertreated <- function(Y, # Outcome variable, (T*N) matrix
         }
     }
 
+    ## Preserve method regardless of r.cv: the bootstrap dispatcher in fect_boot
+    ## has branches for gsynth/ife/mc/cfe but not for "fe", so relabelling to
+    ## "fe" when r.cv == 0 caused stop("Unsupported bootstrap method: fe") whenever
+    ## CV selected the two-way FE model. The gsynth/cfe branches already handle
+    ## r = 0 correctly on the estimation side (inside fect_nevertreated itself).
     if (method == "cfe") {
-        method <- ifelse(r.cv > 0, "cfe", "fe")
+        method <- "cfe"
     } else {
-        method <- ifelse(r.cv > 0, "gsynth", "fe")
+        method <- "gsynth"
     }
 
     ## -------------------------------##

--- a/tests/testthat/test-gsynth-r0-boot.R
+++ b/tests/testthat/test-gsynth-r0-boot.R
@@ -1,0 +1,49 @@
+# Regression test for the "Unsupported bootstrap method: fe" crash when CV
+# selects r = 0 under method = "gsynth".
+#
+# Chain of the original bug (fect <= 2.2.0, diagnosed 2026-04-21):
+#   1. fect(method = "gsynth", CV = TRUE, r = c(0, ...), se = TRUE) dispatches
+#      to fect_nevertreated.
+#   2. When CV picks r.cv == 0, fect_nevertreated used to relabel the outgoing
+#      `method` slot to "fe".
+#   3. fect_boot reads out$method and dispatches per-iteration bootstrap. It
+#      has branches for gsynth / ife / mc / cfe but no "fe" branch, so it
+#      would stop() with "Unsupported bootstrap method: fe".
+#
+# The fix preserves method = "gsynth" (or "cfe") regardless of r.cv. The
+# fixture below is a pure two-way-FE DGP that deterministically makes CV
+# prefer r = 0 over r >= 1, so this test exercises the r.cv == 0 code path.
+
+test_that("gsynth + CV + se survives when r.cv == 0 (regression for dispatcher crash)", {
+  set.seed(20260421)
+  N <- 20
+  TT <- 15
+  id <- rep(seq_len(N), each = TT)
+  time <- rep(seq_len(TT), times = N)
+  alpha <- rnorm(N)
+  xi <- rnorm(TT)
+  D <- as.integer(id <= 5 & time >= 10)
+  Y <- alpha[id] + xi[time] + 2 * D + rnorm(N * TT, sd = 0.5)
+  dat <- data.frame(id = id, time = time, Y = Y, D = D)
+
+  # Before the fix this call raised:
+  #   "Unsupported bootstrap method: fe"
+  out <- fect::fect(
+    Y ~ D,
+    data = dat,
+    index = c("id", "time"),
+    method = "gsynth",
+    CV = TRUE,
+    r = c(0, 3),
+    se = TRUE,
+    nboots = 5,
+    parallel = FALSE
+  )
+
+  expect_s3_class(out, "fect")
+  expect_equal(out$r.cv, 0)
+  # Method must remain "gsynth" after CV; relabel to "fe" was the bug.
+  expect_equal(out$method, "gsynth")
+  expect_true(is.numeric(out$att.avg))
+  expect_true(!is.null(out$est.avg))
+})


### PR DESCRIPTION
## Summary

- `fect_nevertreated()` relabeled its outgoing `$method` from `"gsynth"` / `"cfe"` to `"fe"` whenever CV selected `r.cv = 0`. `fect_boot`'s per-iteration dispatcher has no `"fe"` branch, so every `se = TRUE` call where CV preferred two-way FE crashed with `Error: Unsupported bootstrap method: fe`.
- Fix: keep `method = "gsynth"` / `"cfe"` regardless of `r.cv`. The existing `gsynth` / `cfe` branches in `fect_boot`'s dispatcher already route to `fect_nevertreated`, which handles `r = 0` correctly on the estimation side.
- Reported by John Macdonald against `gsynth`; `gsynth` delegates SE to `fect`. Point estimates were correct; only the SE path failed.
- Version bumped `2.2.0 → 2.2.1` with a NEWS entry describing the fix.

## Test plan

- [x] New regression test `tests/testthat/test-gsynth-r0-boot.R` — pure two-way-FE DGP that deterministically drives CV to `r = 0`; checks `$method == "gsynth"` and `se = TRUE` returns without error.
- [x] Full local test suite with `NOT_CRAN=true`: **591/591 pass**, 0 fail, 0 warn, 0 skip.
- [x] Default `devtools::test()` (CRAN skip active): 265/265, 0 fail.
- [x] `R CMD check --as-cran` on the built tarball: 1 WARNING, 1 NOTE — both pre-existing environmental (macOS clang `-Wfixed-enum-extension` in R's own headers; `HonestDiDFEct` is a GitHub-only Suggests dependency).
- [x] End-to-end verified against the reporter's reproducer with `nboots = 100`: returns valid ATT, SE, CI, p-value.