### PR TITLE
fix(boot): Phase A foreach → future_lapply, drop doFuture pollution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,26 @@ Parallel cross-validation:
   `fit_test`, `permutation`, `fect_sens`, or `did_wrapper` — five sites had
   legacy scalar `parallel == TRUE` / `if (parallel)` checks.
 
+## Parallelism cleanup (Phase A bootstrap)
+
+* Phase A's bootstrap error simulation (`R/boot.R::draw.error`) migrated
+  from `foreach %dopar%` to `future.apply::future_lapply`. The old
+  `%dopar%` inherited whatever backend was registered globally; after any
+  prior parallel fect call, `run_dopar_retry`'s `on.exit` left `doFuture`
+  registered, so a subsequent call's Phase A inherited a backend that
+  shipped heavy closures per iteration --- producing an ~8x slowdown on
+  variant (iii) bootstraps in multi-fit sessions (e.g., a forest plot run).
+
+* The `doFuture::registerDoFuture()` re-registration inside
+  `run_dopar_retry`'s `on.exit` was removed; it was the source of the
+  global state pollution. The function still falls back to `doParallel`
+  if the future backend errors; it just no longer leaves a global
+  doFuture registration behind.
+
+* New regression test (`tests/testthat/test-phase-a-future-state.R`):
+  asserts two consecutive `fect(parallel = TRUE)` calls in the same R
+  process have wall-time ratio < 3x.
+
 # fect 2.2.0
 
 * Added CFE (Complex Fixed Effects) estimator (`method = "cfe"`)

--- a/R/boot.R
+++ b/R/boot.R
@@ -882,21 +882,15 @@ fect_boot <- function(
 
     message("\rSimulating errors ...")
     if (do_parallel_boot) {
-      error.tr <- suppressWarnings(foreach(
-        j = 1:nboots,
-        .combine = function(...) abind(..., along = 3),
-        .multicombine = TRUE,
-        .export = c("impute_Y0", "valid_controls",
-                     "fect_nevertreated", "fect_fe", "fect_cfe", "initialFit",
-                     ".reconstruct_gamma_fit_tr", ".reconstruct_kappa_fit",
-                     ".extract_and_apply_typeB_fe"),
-        .packages = c("fect", "mvtnorm", "fixest"),
-        .options.future = list(seed = TRUE),
-        .inorder = FALSE
-      ) %dopar%
-        {
-          return(draw.error())
-        })
+      ## Phase A: future_lapply (was foreach %dopar%, which inherited whatever
+      ## backend the global foreach registry held — see notes/ stage-1).
+      error.list <- future.apply::future_lapply(
+        seq_len(nboots),
+        FUN = function(j) draw.error(),
+        future.seed = TRUE,
+        future.packages = c("fect", "mvtnorm", "fixest")
+      )
+      error.tr <- abind(error.list, along = 3)
     } else {
       error.tr <- array(NA, dim = c(TT, Ntr, nboots))
       for (j in 1:nboots) {
@@ -1560,7 +1554,6 @@ fect_boot <- function(
       cl <- parallel::makePSOCKcluster(workers)
       on.exit({
         try(parallel::stopCluster(cl), silent = TRUE)
-        try(suppressWarnings(suppressPackageStartupMessages(doFuture::registerDoFuture())), silent = TRUE)
       }, add = TRUE)
       doParallel::registerDoParallel(cl)
       suppressWarnings(foreach(

--- a/tests/testthat/test-phase-a-future-state.R
+++ b/tests/testthat/test-phase-a-future-state.R
@@ -1,0 +1,61 @@
+## ---------------------------------------------------------------
+## Regression test: Phase A bootstrap parallel state across calls.
+##
+## Pre-fix bug (HANDOFF 2026-04-25): boot.R Phase A's foreach %dopar%
+## inherited whatever foreach backend was registered in the global
+## registry. After any prior fect parallel call, run_dopar_retry's
+## on.exit re-registered doFuture, polluting subsequent calls --
+## variant (iii) Phase A in a forest session ran 8x slower than the
+## same call in isolation.
+##
+## Fix (Stage 1, 2026-04-25):
+##   1. Phase A migrated from foreach %dopar% to future_lapply
+##      (boot.R:884). Backend is now governed by the active future plan
+##      set in default.R, not by a global foreach registry.
+##   2. Removed `doFuture::registerDoFuture()` from run_dopar_retry's
+##      on.exit (boot.R:1553).
+##
+## Test: two consecutive fect(parallel = TRUE) calls in the same R
+## process. The second call's wall-time must be within 2x of the
+## first; pre-fix this could blow up to 8x.
+## ---------------------------------------------------------------
+
+test_that("Phase A wall-time is stable across consecutive parallel calls", {
+
+  skip_on_cran()
+
+  one_call <- function(seed) {
+    set.seed(seed)
+    t0 <- Sys.time()
+    suppressWarnings(suppressMessages(
+      fect::fect(
+        Y ~ D,
+        data      = simdata,
+        index     = c("id", "time"),
+        method    = "ife",
+        r         = 1,
+        CV        = FALSE,
+        force     = "two-way",
+        time.component.from = "nevertreated",
+        se        = TRUE,
+        vartype   = "bootstrap",
+        nboots    = 20,
+        parallel  = TRUE,
+        cores     = 2
+      )
+    ))
+    as.numeric(difftime(Sys.time(), t0, units = "secs"))
+  }
+
+  ## Warm-up: pay future plan / package-load cost outside the measurement.
+  invisible(one_call(seed = 1))
+
+  ## First measured call.
+  t1 <- one_call(seed = 2)
+  ## Second measured call -- must not blow up due to backend pollution.
+  t2 <- one_call(seed = 3)
+
+  ratio <- t2 / max(t1, 0.5)
+  ## 2x is the plan budget; allow 3x ceiling to absorb GC / OS jitter on CI.
+  expect_lt(ratio, 3)
+})


### PR DESCRIPTION
## Summary

- Phase A bootstrap error simulation (`boot.R::draw.error`) migrated from `foreach %dopar%` to `future.apply::future_lapply`. The old `%dopar%` inherited whatever backend was registered in the global foreach registry, which after any prior fect parallel call was `doFuture` (re-registered by `run_dopar_retry`'s `on.exit`). In a forest session this caused variant (iii) Phase A to ship heavy closures per-iteration to future workers, running ~8x slower than the same call in isolation.
- Dropped the `doFuture::registerDoFuture()` line in `run_dopar_retry`'s `on.exit`. The doParallel retry only fires when the future backend errored; restoring doFuture afterwards was the bug, not the fix.
- NEWS bullet added under `# fect 2.3.0 (development)`: new `## Parallelism cleanup (Phase A bootstrap)` section.
- Stage 1 of the 7-stage cleanup plan in gsynth-note's HANDOFF.

## Test plan

- [x] Local smoke (M-series, 2 cores, simdata, nboots=20): warmup 4.06s | call 1 3.56s | call 2 4.16s | ratio 1.17x. ATTs identical between calls (2.9062).
- [x] EH 2023 forest in-session: variant (iii) on sec_enrol runs 101.4s in-session vs 104s standalone. The 8x session-state slowdown is gone.
- [x] New regression test: `tests/testthat/test-phase-a-future-state.R` asserts two consecutive `fect(parallel = TRUE)` calls in the same R process have wall-time ratio < 3x.
- [x] Reviewer: confirm CI passes on `R CMD check --as-cran`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)