### PR TITLE
feat(gsc): populate Y.ct.full at control positions with F*t(lambda_co)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,24 @@ Parallel cross-validation:
   `fit_test`, `permutation`, `fect_sens`, or `did_wrapper` — five sites had
   legacy scalar `parallel == TRUE` / `if (parallel)` checks.
 
+## GSC: Y.ct.full populated at control positions
+
+* On the GSC path (`method = "ife"` with
+  `time.component.from = "nevertreated"`), `Y.ct.full[, co]` is now
+  overwritten with the model-implied factor product `F * t(lambda_co)`
+  after the shared `Y.ct.full <- Y.ct` assignment (sourced from
+  `est.co.best$factor` and `est.co.best$lambda`, gated on dim agreement
+  and non-empty rank). Closes a gap that left `NA` at masked control
+  positions because the residual recipe `Y.co - residuals` propagates
+  `NA`. Enables user-space rolling CV (`r.cv.rolling()`) for
+  `method = "gsynth"`.
+
+* No change to ATT, gap, or `est.avg`: those are computed from
+  treated-unit positions and do not consume `Y.ct.full[, co]`. Verified
+  on the `simgsynth` anchor (set.seed(11), r=2, force="two-way"):
+  ATT.avg unchanged at 4.639593 vs unmodified dev; new control-column
+  contents match `F * t(lambda.co)` with max abs diff = 0.
+
 # fect 2.2.0
 
 * Added CFE (Complex Fixed Effects) estimator (`method = "cfe"`)

--- a/R/fect_nevertreated.R
+++ b/R/fect_nevertreated.R
@@ -2612,6 +2612,24 @@ fect_nevertreated <- function(Y, # Outcome variable, (T*N) matrix
 
     ## 3. unbalanced output
     Y.ct.full <- Y.ct
+    ## Stage 2: populate Y.ct.full at control positions on the GSC path.
+    ## On the IFE-EM (notyettreated) path EM imputation already fills in
+    ## masked control positions, so user-space rolling CV can read off
+    ## fit$Y.ct.full there. On GSC the residual recipe `Y.co - residuals`
+    ## leaves NA at masked positions because Y.co is NA. Overwriting with
+    ## the model-implied F * t(lambda_co) closes that gap. ATT, gap, and
+    ## est.avg are computed from treated units only and are unaffected.
+    if (method == "ife" &&
+        !is.null(est.co.best$factor) &&
+        !is.null(est.co.best$lambda)) {
+        F.hat.ctf     <- as.matrix(est.co.best$factor)
+        Lambda.co.ctf <- as.matrix(est.co.best$lambda)
+        if (ncol(F.hat.ctf) > 0 &&
+            ncol(F.hat.ctf) == ncol(Lambda.co.ctf) &&
+            nrow(F.hat.ctf) == TT && nrow(Lambda.co.ctf) == Nco) {
+            Y.ct.full[, co] <- F.hat.ctf %*% t(Lambda.co.ctf)
+        }
+    }
     res.full <- Y - Y.ct
     if (0 %in% I) {
         eff[which(I == 0)] <- NA

--- a/tests/testthat/test-yctfull-gsc.R
+++ b/tests/testthat/test-yctfull-gsc.R
@@ -1,0 +1,94 @@
+## ---------------------------------------------------------------
+## Regression test: Y.ct.full populated at control positions on GSC.
+##
+## Pre-fix (HANDOFF 2026-04-25): On the GSC path
+## (method = "ife" + time.component.from = "nevertreated"), Y.ct.full
+## at id_co positions was set via `Y.co - residuals`, which leaves NA
+## at any position where Y.co is NA. This blocks user-space rolling CV
+## from scoring MSPE at masked control observations -- the channel
+## that R/cv-rolling.R uses to evaluate held-out positions.
+##
+## Fix (Stage 2, 2026-04-25): After Y.ct.full <- Y.ct on the shared
+## post-bifurcation path of fect_nevertreated.R, on the IFE method
+## branch (the GSC estimator) overwrite control columns with the
+## model-implied factor product:
+##     Y.ct.full[, id_co] <- F * t(lambda_co)
+## sourced directly from est.co.best$factor and est.co.best$lambda.
+##
+## Tests:
+##   1. fit$Y.ct.full[, fit$co] matches F * t(lambda) element-wise.
+##   2. ATT.avg matches the unmodified-dev baseline (4.639593 on
+##      simgsynth, set.seed(11), r=2, CV=FALSE, force="two-way").
+## ---------------------------------------------------------------
+
+test_that("GSC populates Y.ct.full[, co] with F * t(lambda)", {
+
+  skip_on_cran()
+
+  if (!exists("simgsynth", inherits = TRUE)) {
+    suppressWarnings(try(utils::data("simgsynth", package = "fect"),
+                         silent = TRUE))
+  }
+  skip_if_not(exists("simgsynth", inherits = TRUE),
+              "simgsynth dataset not available")
+
+  set.seed(11)
+  fit <- suppressWarnings(suppressMessages(
+    fect::fect(
+      Y ~ D,
+      data      = simgsynth,
+      index     = c("id", "time"),
+      method    = "ife",
+      time.component.from = "nevertreated",
+      r         = 2,
+      CV        = FALSE,
+      force     = "two-way",
+      se        = FALSE
+    )
+  ))
+
+  expect_true(!is.null(fit$factor))
+  expect_true(!is.null(fit$lambda.co))
+  expect_true(!is.null(fit$Y.ct.full))
+  expect_true(!is.null(fit$co))
+
+  F.hat <- as.matrix(fit$factor)
+  L.co  <- as.matrix(fit$lambda.co)
+  expected <- F.hat %*% t(L.co)
+
+  observed <- fit$Y.ct.full[, fit$co, drop = FALSE]
+
+  expect_equal(dim(observed), dim(expected))
+  expect_equal(observed, expected, tolerance = 1e-10,
+               ignore_attr = TRUE)
+})
+
+test_that("GSC ATT.avg unchanged after Stage 2 patch (simgsynth anchor)", {
+
+  skip_on_cran()
+
+  if (!exists("simgsynth", inherits = TRUE)) {
+    suppressWarnings(try(utils::data("simgsynth", package = "fect"),
+                         silent = TRUE))
+  }
+  skip_if_not(exists("simgsynth", inherits = TRUE),
+              "simgsynth dataset not available")
+
+  set.seed(11)
+  fit <- suppressWarnings(suppressMessages(
+    fect::fect(
+      Y ~ D,
+      data      = simgsynth,
+      index     = c("id", "time"),
+      method    = "ife",
+      time.component.from = "nevertreated",
+      r         = 2,
+      CV        = FALSE,
+      force     = "two-way",
+      se        = FALSE
+    )
+  ))
+
+  ## Anchor: 4.639593 on unmodified dev, set.seed(11), simgsynth.
+  expect_equal(fit$att.avg, 4.639593, tolerance = 1e-5)
+})


### PR DESCRIPTION
## Summary

- On the GSC path (`method = "ife"` + `time.component.from = "nevertreated"`), `Y.ct.full[, co]` was previously set via `Y.co - residuals`, which leaves `NA` at any position where `Y.co` is `NA`. This blocks user-space rolling CV from reading model-implied values at masked control observations -- the channel `R/cv-rolling.R` uses to score MSPE on held-out positions, and the reason `cv.rolling` currently errors out for `method = "gsynth"`.
- The IFE-EM path (`notyettreated`) already populates these positions via EM imputation. This patch closes the gap on the GSC path with a 5-line overwrite: after `Y.ct.full <- Y.ct` on the shared post-bifurcation code, replace control columns with the model-implied factor product `F * t(lambda_co)` sourced directly from `est.co.best$factor` and `est.co.best$lambda` (gated on dim agreement and non-empty rank).
- ATT, gap, and est.avg are computed from treated-unit positions and are unaffected by this overwrite.
- NEWS bullet added under `# fect 2.3.0 (development)`: new `## GSC: Y.ct.full populated at control positions` section.
- Stage 2 of the 7-stage cleanup plan; **PR #119's rolling CV `method = "gsynth"` support depends on this PR landing first.**

## Test plan

- [x] Verified on simgsynth (set.seed(11), r=2, force="two-way"): ATT.avg unchanged at 4.639593 vs unmodified dev. New control-column contents match `F * t(lambda.co)` with max abs diff = 0.
- [x] EH 2023 quick CV validation (4 cells × both estimators): `r.cv.rolling(method = "gsynth")` end-to-end works post-this-patch (was previously blocked).
- [x] New regression test: `tests/testthat/test-yctfull-gsc.R`.
- [x] Reviewer: confirm `R CMD check --as-cran` passes; spot-check that no other consumer of `Y.ct.full[, co]` depends on the old `Y.co - residuals` recipe (ATT/gap/est.avg do not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)