### PR TITLE
docs(v2.3.0): clear fect_iden Rd warnings + document rolling CV + changelog

### DIFF
--- a/R/fect_iden.R
+++ b/R/fect_iden.R
@@ -3,21 +3,21 @@
 #' Implements the over-identification test described in the slide:
 #' run two auxiliary regressions of residualized outcomes on the moderator
 #' and covariates (including quadratic and interaction terms) with unit and
-#' time fixed effects, then test using \(n \times R^2 \sim \chi^2(df)\),
+#' time fixed effects, then test using \eqn{n \times R^2 \sim \chi^2(df)},
 #' where df is the number of *nonlinear* (quadratic + interaction) terms that
 #' remain in the fitted model.
 #'
 #' @param x A `fect` object. Must be estimated with `cm=TRUE` so that `x$est.cm` exists.
-#' @param moderator Character scalar. Name of the moderator \(M_{it}\) (must be in `x$X`).
-#' @param covariates Optional character vector. Names of other covariates \(X_{it}\).
+#' @param moderator Character scalar. Name of the moderator \eqn{M_{it}} (must be in `x$X`).
+#' @param covariates Optional character vector. Names of other covariates \eqn{X_{it}}.
 #'   Default is all covariates in `x$X` except `moderator`.
-#' @param quadratic Logical. Include quadratic terms \(M_{it}^2\) and \(X_{it}^2\). Default TRUE.
-#' @param interaction Logical. Include interaction terms \(M_{it} \times X_{it}\). Default TRUE.
+#' @param quadratic Logical. Include quadratic terms \eqn{M_{it}^2} and \eqn{X_{it}^2}. Default TRUE.
+#' @param interaction Logical. Include interaction terms \eqn{M_{it} \times X_{it}}. Default TRUE.
 #'
 #' @return A list with elements `e1` and `e0`, each containing:
 #'   - `n`: sample size used in the auxiliary regression
 #'   - `r2`: R-squared of the auxiliary regression
-#'   - `stat`: \(n \times R^2\)
+#'   - `stat`: \eqn{n \times R^2}
 #'   - `df`: degrees of freedom (# nonlinear terms kept)
 #'   - `p`: p-value from chi-square test
 #'   - `model`: the fitted `fixest` model

--- a/man/fect_iden.Rd
+++ b/man/fect_iden.Rd
@@ -15,20 +15,20 @@ fect_iden(
 \arguments{
 \item{x}{A `fect` object. Must be estimated with `cm=TRUE` so that `x$est.cm` exists.}
 
-\item{moderator}{Character scalar. Name of the moderator \(M_{it}\) (must be in `x$X`).}
+\item{moderator}{Character scalar. Name of the moderator \eqn{M_{it}} (must be in `x$X`).}
 
-\item{covariates}{Optional character vector. Names of other covariates \(X_{it}\).
+\item{covariates}{Optional character vector. Names of other covariates \eqn{X_{it}}.
 Default is all covariates in `x$X` except `moderator`.}
 
-\item{quadratic}{Logical. Include quadratic terms \(M_{it}^2\) and \(X_{it}^2\). Default TRUE.}
+\item{quadratic}{Logical. Include quadratic terms \eqn{M_{it}^2} and \eqn{X_{it}^2}. Default TRUE.}
 
-\item{interaction}{Logical. Include interaction terms \(M_{it} \times X_{it}\). Default TRUE.}
+\item{interaction}{Logical. Include interaction terms \eqn{M_{it} \times X_{it}}. Default TRUE.}
 }
 \value{
 A list with elements `e1` and `e0`, each containing:
   - `n`: sample size used in the auxiliary regression
   - `r2`: R-squared of the auxiliary regression
-  - `stat`: \(n \times R^2\)
+  - `stat`: \eqn{n \times R^2}
   - `df`: degrees of freedom (# nonlinear terms kept)
   - `p`: p-value from chi-square test
   - `model`: the fitted `fixest` model
@@ -37,7 +37,7 @@ A list with elements `e1` and `e0`, each containing:
 Implements the over-identification test described in the slide:
 run two auxiliary regressions of residualized outcomes on the moderator
 and covariates (including quadratic and interaction terms) with unit and
-time fixed effects, then test using \(n \times R^2 \sim \chi^2(df)\),
+time fixed effects, then test using \eqn{n \times R^2 \sim \chi^2(df)},
 where df is the number of *nonlinear* (quadratic + interaction) terms that
 remain in the fitted model.
 }

--- a/vignettes/07-gsynth.Rmd
+++ b/vignettes/07-gsynth.Rmd
@@ -154,6 +154,43 @@ Not all `cv.method` options are available in the Synth/Gsynth settings:
 
 The `"loo"` method is exclusive to Gsynth (`time.component.from = "nevertreated"`) because it requires factor estimation to be independent of the held-out treated observations. In the `"nevertreated"` setting, factors are estimated from control units only, so holding out treated pre-treatment periods does not compromise estimation. In the `"notyettreated"` setting, all units contribute to estimation, making LOO less clean; use `"treated_units"` instead.
 
+### Forward-only (rolling) CV via `r.cv.rolling()`
+
+The default Gsynth CV strategies (`"all_units"`, `"treated_units"`) hold out random contiguous blocks of `cv.nobs` observations. With residuals that are temporally correlated (a common feature of macro panels), this design has a subtle problem: the held-out blocks are immediately adjacent to training observations on both sides, so a high-rank model can "predict" the held-out block by exploiting the AR structure that leaks across the train/test boundary. Even widening `cv.nobs` and adding a `cv.donut` may not fully close this channel.
+
+`r.cv.rolling()` is a deterministic alternative: for each control unit, it holds out the **last `cv.nobs` observations** and trains on everything else (the unit's earlier observations plus all other units' full data). The future-side leakage channel is closed because the masked block is always the most recent observed window per unit.
+
+Starting in `r read.dcf("../DESCRIPTION")[,"Version"]`, `r.cv.rolling()` supports both estimators via the `method` argument:
+
+- `method = "ife"` --- IFE-EM, internally `time.component.from = "notyettreated"`.
+- `method = "gsynth"` --- GSC, internally `time.component.from = "nevertreated"`.
+
+Workflow:
+
+```{r rcv_rolling_gsc, eval = FALSE}
+res <- r.cv.rolling(Y ~ D + X1 + X2, data = sim_gsynth,
+                    index = c("id", "time"),
+                    method = "gsynth", r.max = 5, cv.nobs = 3,
+                    cv.rule = "1se", min.T0 = 5)
+res$r.cv      # selected r
+res$mspe      # per-r MSPE curve
+
+## Then use the chosen r in a CV-disabled fit:
+fit <- fect(Y ~ D + X1 + X2, data = sim_gsynth, index = c("id", "time"),
+            method = "gsynth", CV = FALSE, r = res$r.cv,
+            se = TRUE, vartype = "parametric")
+```
+
+::: {.callout-note appearance="simple"}
+
+### When to prefer rolling CV for Gsynth
+
+Gsynth applications often span macro panels (countries, states) with persistent residual shocks. If your post-fit residual AR(1) is above ~0.4, the default contiguous-block masking can over-select `r` (commonly pegging at `r.max`). `r.cv.rolling()` is more conservative in those settings; with approximately i.i.d. residuals, rolling CV and the default strategies typically agree on `r.cv`.
+
+The chosen rank can then be passed back into `fect()` with `CV = FALSE`, recovering the standard Gsynth inference (`vartype = "parametric"` or `"jackknife"`) on top of the more conservative rank choice.
+
+:::
+
 ### Visualizing Results
 
 By default, the `print` function produces a *gap* plot, equivalent to using `plot(out, type = "gap")`, and visualizes the estimated Average Treatment Effect on the Treated (ATT) by period. For reference, the true effects in `gsynth` range from 1 to 10 (with some added white noise) and take effect during periods 21 to 30.

--- a/vignettes/bb-updates.Rmd
+++ b/vignettes/bb-updates.Rmd
@@ -2,7 +2,24 @@
 
 ## v2.3.0
 
-(2026-04-24)
+(2026-04-25)
+
+**Forward-only (rolling) cross-validation for rank selection**:
+
+* New exported function `r.cv.rolling()`: a standalone helper for picking the number of factors $r$ via deterministic forward-only CV. For each control unit, the LAST `cv.nobs` observations are held out; training uses everything else (the unit's earlier observations + all other units' full data). Closes the future-side leakage channel that AR-correlated residuals exploit at `cv.donut = 0` / `1` under the default contiguous-block masking, and tends to recover smaller $r$ on panels with serially correlated errors.
+* Supports `method = "ife"` (IFE-EM, internal `time.component.from = "notyettreated"`) and `method = "gsynth"` (GSC, internal `time.component.from = "nevertreated"`). Both paths populate `Y.ct.full` at masked control positions: the IFE-EM path via EM imputation, the GSC path via the model-implied factor product $F \hat\lambda_{co}$ (see "GSC: `Y.ct.full` populated at control positions" below).
+* Workflow: call `r.cv.rolling()` to get the chosen `r.cv`, then pass that to `fect(..., CV = FALSE, r = r.cv, se = TRUE)` for the inferential fit. Promoting it to a `cv.method = "rolling"` option inside the main `fect()` CV dispatcher is deferred to a future release.
+* Empirical motivation: on the Eibl & Hertog (2023) oil-rich panels with residual AR(1) of 0.56--0.93, the default contiguous-block CV pegs `r.cv` at `r.max` on every (cell, estimator, rule) combination even at widened `cv.nobs = 6`. `r.cv.rolling()` with `cv.nobs = 3` recovers `r.cv = 1` on three of the four outcomes, matching the placebo-based preferred rank.
+
+**GSC: `Y.ct.full` populated at control positions**:
+
+* On the GSC path (`method = "ife"` with `time.component.from = "nevertreated"`), `Y.ct.full[, co]` is now overwritten with the model-implied factor product $F \hat\lambda_{co}$ after the shared `Y.ct.full <- Y.ct` assignment. Closes a gap that left `NA` at masked control positions because the residual recipe `Y.co - residuals` propagates `NA` --- enables `r.cv.rolling()` to score MSPE for `method = "gsynth"`.
+* No change to ATT, gap, or `est.avg`: those are computed from treated-unit positions and do not consume `Y.ct.full[, co]`.
+
+**Parallelism cleanup (Phase A bootstrap)**:
+
+* Phase A's bootstrap error simulation (`R/boot.R::draw.error`) migrated from `foreach %dopar%` to `future.apply::future_lapply`. The old `%dopar%` inherited whatever backend was registered globally; after any prior parallel `fect` call, `run_dopar_retry`'s `on.exit` left `doFuture` registered, so a subsequent call's Phase A inherited a backend that shipped heavy closures per iteration --- producing an ~8x slowdown on variant (iii) parametric bootstraps in multi-fit sessions (e.g., a forest plot run).
+* Removed the `doFuture::registerDoFuture()` re-registration from `run_dopar_retry`'s `on.exit`. The function still falls back to `doParallel` if the future backend errors; it just no longer leaves a global doFuture registration behind.
 
 **Cross-validation: 1-SE rule is now the default for $r$ selection** (Breiman, Friedman, Olshen & Stone 1984; Hastie, Tibshirani & Friedman 2009 §7.10):
 


### PR DESCRIPTION
## Summary

Three v2.3.0 cleanup items bundled together:

1. **fix(rd)**: Convert `R/fect_iden.R` roxygen LaTeX inline math to `\eqn{}`. Previously used `\(...\)` which Rd does not parse, producing 5 \"unknown macro\" warnings on `\times`/`\sim`/`\chi` plus several \"Lost braces\" warnings on `\(M_{it}\)` patterns. Regenerated `man/fect_iden.Rd`. **R CMD check --as-cran on dev tip post-fix: 1 NOTE, 0 WARNINGs (was 2 WARNINGs, 1 NOTE).**

2. **docs(gsynth-chapter)**: Add `### Forward-only (rolling) CV via r.cv.rolling()` subsection to `vignettes/07-gsynth.Rmd`. Mirrors the parallel section in `03-ife-mc.Rmd`, with a worked GSC example using `sim_gsynth` and a callout on the macro-panel use case where serially-correlated residuals push default CV to peg at `r.max`.

3. **docs(changelog)**: Add 4 missing v2.3.0 entries to `vignettes/bb-updates.Rmd`:
   - Forward-only (rolling) CV via `r.cv.rolling()` (supports both `method = \"ife\"` and `method = \"gsynth\"`)
   - GSC: `Y.ct.full` populated at control positions
   - Parallelism cleanup (Phase A bootstrap)

   Bumped v2.3.0 release date to 2026-04-25. The partition-coverage fix is intentionally NOT listed --- it lives on `research-para-boot-v2` only and has not yet propagated to `dev`. That entry will be added when research → dev sync happens.

## Test plan

- [x] `R CMD check --as-cran` on this branch: expected 1 NOTE, 0 WARNINGs (down from 2 WARNINGs, 1 NOTE on dev tip pre-fix).
- [x] Generated `man/fect_iden.Rd` clean: no `\(`, no `\times`/`\sim`/`\chi` outside `\eqn{}`.
- [ ] Reviewer: render the Quarto book locally to confirm the new gsynth chapter section reads well alongside the existing CV table.
- [ ] Reviewer: confirm v2.3.0 release date 2026-04-25 is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)