### PR TITLE
fix(weights): consistent ATT surface + W.est/W.agg per-role weights (v2.3.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: fect
 Type: Package
 Title: Fixed Effects Counterfactual Estimators
-Version: 2.3.0
-Date: 2026-04-24
+Version: 2.3.1
+Date: 2026-04-27
 Authors@R: 
     c(person("Licheng", "Liu", , "lichengl@stanford.edu", role = c("aut")), 
       person("Ziyi", "Liu", , "zyliu2023@berkeley.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,89 @@
+# fect 2.3.1 (development)
+
+## New: `W.est` and `W.agg` arguments distinguish survey weights from IPW / balancing weights
+
+`fect()` and `fect.formula()` gain two new arguments that control where
+the weight column enters the estimator:
+
+* `W.est` --- weight column for the outcome-model fit (the weighted least
+  squares applied inside the IFE / MC / CFE solver).
+* `W.agg` --- weight column for the across-treated-obs aggregation
+  (`att.on`, `est.avg`, `est.att`).
+
+Both default to `NULL` and fall back to the existing `W` argument when
+left unset, so callers who pass only `W = "col"` get the same behavior as
+v2.3.0 + the consistency fix below (W enters both fit and aggregation).
+Pass the per-role arguments to specify finer behavior:
+
+* Survey / sample weights: `W = "ws"` (or equivalently
+  `W.est = W.agg = "ws"`). W enters both fit and aggregation.
+* Robust-regression / heteroskedasticity / GLS weights: `W.est = "wr"`
+  alone. The fit is weighted, the aggregation is unweighted.
+* Inverse-probability / balancing / post-stratification weights:
+  `W.agg = "ipw"` alone. The outcome model is fit unweighted (preserving
+  doubly-robust properties), and the aggregation is weighted by IPW.
+
+In v2.3.1, `W.est` and `W.agg` (when both supplied) must point to the
+same column. Truly distinct columns for fit vs. aggregation (e.g. a
+combined survey x IPW design where the outcome model uses survey weights
+and the aggregation uses survey x IPW) are scheduled for v2.4.0; the
+v2.3.1 design errors with an instructive message if requested.
+
+**Caveat for IPW users.** `W.agg = "ipw"` fits the outcome model
+unweighted and applies IPW only at the across-treated-obs aggregation.
+This is closer to a doubly-robust estimator than v2.3.0's silent
+everywhere-weighting --- but it is not a fully cross-fit doubly-robust
+estimator. Residuals on never-treated controls used in any de-bias term
+inherit in-sample shrinkage from the outcome fit, which DR theory
+requires cross-fitting to eliminate. A fully cross-fit DR path is
+scheduled for v3.0.
+
+## Breaking change: weighted fits now have a single, consistent ATT surface
+
+When `W = "<column>"` is supplied to `fect()`, every reported quantity on
+the returned fit object now reflects those weights. Prior versions
+maintained two parallel ATT pipelines on weighted fits: an unweighted one
+(populated into `est.att`, `est.avg`, `att.boot`, `att.vcov`, etc.) and a
+W-weighted one (populated into the parallel `est.att.W`, `est.avg.W`,
+`att.W.boot`, `att.W.vcov` slots). `plot(fit)` silently substituted the
+W-weighted pipeline for rendering while `print(fit)` and `fit$est.att`
+returned the unweighted pipeline --- so the same fit object reported
+different per-period ATTs and aggregate CIs depending on which surface
+the user looked at.
+
+As of 2.3.1, when `W` is non-NULL:
+
+* `fit$est.att`, `fit$est.avg`, `fit$est.att90`, `fit$att.bound`,
+  `fit$att.boot`, `fit$att.vcov`, `fit$est.placebo`, `fit$est.carryover`,
+  and the `*.off` reverse-treatment counterparts all carry the
+  W-weighted aggregations.
+* `fit$att`, `fit$time`, `fit$count`, `fit$att.avg`, `fit$att.off`,
+  `fit$time.off`, `fit$count.off`, `fit$att.placebo`, `fit$att.carryover`
+  similarly carry the W-weighted aggregations from the per-method
+  estimator.
+* `print(fit)` now labels the obs-level row as `Tr obs sample-weighted (W)`
+  (instead of `Tr obs equally weighted`) when W was supplied.
+* The redundant `*.W` slots (`est.att.W`, `est.avg.W`, `att.W.boot`,
+  `att.W.vcov`, `att.W.bound`, `att.on.W`, `time.on.W`, `count.on.W`,
+  `att.avg.W`, `att.on.sum.W`, `W.on.sum`, `att.off.W`, `time.off.W`,
+  `count.off.W`, `att.off.sum.W`, `W.off.sum`, `att.placebo.W`,
+  `att.carryover.W`, `est.placebo.W`, `est.carryover.W`, `est.att.off.W`,
+  `att.off.W.bound`, `att.off.W.vcov`) are no longer present on the
+  returned fit object.
+
+If you want the unweighted view of the same fit, refit with `W = NULL`.
+
+The `weight` argument to `plot.fect()` is now a no-op (deprecated),
+slated for removal in v2.5.0; passing it emits a deprecation warning.
+Internally `plot.fect()` no longer auto-flips between two pipelines ---
+it reads the canonical slots, which are already W-weighted when W was
+supplied at fit time.
+
+The C++ matrix-completion / IFE / CFE solvers (`inter_fe_mc`,
+`inter_fe_ub`, `inter_fe_cfe`) already used W as a fit-time
+weighted-least-squares weight in 2.3.0; this release does not change the
+fit, only the result-object surface.
+
 # fect 2.3.0 (development)
 
 ## Rolling-window cross-validation (standard ML design)

--- a/R/boot.R
+++ b/R/boot.R
@@ -121,7 +121,9 @@ fect_boot <- function(
   time.component.from = "notyettreated",
   loading.bound = "none",
   gamma.loading = NULL,
-  gamma.loading.grid = NULL
+  gamma.loading.grid = NULL,
+  W.in.fit = TRUE,
+  W.in.agg = TRUE
 ) {
   do_parallel_boot <- isTRUE(parallel) || "boot" %in% as.character(parallel)
   na.pos <- NULL
@@ -185,6 +187,7 @@ fect_boot <- function(
         X = X,
         D = D,
         W = W,
+        W.in.fit = W.in.fit,
         I = I,
         II = II,
         T.on = T.on,
@@ -217,6 +220,7 @@ fect_boot <- function(
         X = X,
         D = D,
         W = W,
+        W.in.fit = W.in.fit,
         I = I,
         II = II,
         cm = cm,
@@ -249,6 +253,7 @@ fect_boot <- function(
           X = X,
           D = D,
           W = W,
+          W.in.fit = W.in.fit,
           I = I,
           II = II,
           T.on = T.on,
@@ -282,6 +287,7 @@ fect_boot <- function(
           X = X,
           D = D,
           W = W,
+          W.in.fit = W.in.fit,
           I = I,
           II = II,
           T.on = T.on,
@@ -326,6 +332,7 @@ fect_boot <- function(
           X = X,
           D = D,
           W = W,
+          W.in.fit = W.in.fit,
           X.extra.FE = X.extra.FE,
           X.Z = X.Z,
           X.Q = X.Q,
@@ -375,6 +382,7 @@ fect_boot <- function(
         X = X,
         D = D,
         W = W,
+        W.in.fit = W.in.fit,
         I = I,
         II = II,
         T.on = T.on,
@@ -684,6 +692,7 @@ fect_boot <- function(
           X = X,
           D = D,
           W = W,
+          W.in.fit = W.in.fit,
           I = I,
           II = II,
           cm = cm,
@@ -1277,6 +1286,7 @@ fect_boot <- function(
               X = X.boot,
               D = D.boot,
               W = W.boot,
+              W.in.fit = W.in.fit,
               I = I.boot,
               II = II[, boot.id],
               T.on = T.on[, boot.id],
@@ -1320,6 +1330,7 @@ fect_boot <- function(
               X = X.boot,
               D = D.boot,
               W = W.boot,
+              W.in.fit = W.in.fit,
               I = I.boot,
               II = II[, boot.id],
               cm = cm,
@@ -1363,6 +1374,7 @@ fect_boot <- function(
               X = X.boot,
               D = D[, boot.id],
               W = W.boot,
+              W.in.fit = W.in.fit,
               I = I[, boot.id],
               II = II[, boot.id],
               T.on = T.on[, boot.id],
@@ -1408,6 +1420,7 @@ fect_boot <- function(
               X = X.boot,
               D = D.boot,
               W = W.boot,
+              W.in.fit = W.in.fit,
               X.extra.FE = X.extra.FE.boot,
               X.Z = X.Z.boot,
               X.Q = X.Q.boot,
@@ -3057,6 +3070,23 @@ fect_boot <- function(
       colnames(att.W.bound) <- c("CI.lower", "CI.upper")
       rownames(att.W.bound) <- time.on.W
 
+      est.att90.W <- cbind(
+        att.on.W,
+        att.on.W.j$se,
+        att.W.bound,
+        att.on.W.j$P,
+        count.on.W
+      )
+      colnames(est.att90.W) <- c(
+        "ATT",
+        "S.E.",
+        "CI.lower",
+        "CI.upper",
+        "p.value",
+        "count"
+      )
+      rownames(est.att90.W) <- time.on.W
+
       if (!is.null(placebo.period) & placeboTest == TRUE) {
         att.placebo.W.j <- jackknifed(
           att.placebo.W,
@@ -3840,6 +3870,23 @@ fect_boot <- function(
       colnames(att.W.bound) <- c("CI.lower", "CI.upper")
       rownames(att.W.bound) <- time.on.W
 
+      est.att90.W <- cbind(
+        att.on.W,
+        se.att.W,
+        att.W.bound,
+        pvalue.att.W,
+        count.on.W
+      )
+      colnames(est.att90.W) <- c(
+        "ATT",
+        "S.E.",
+        "CI.lower",
+        "CI.upper",
+        "p.value",
+        "count"
+      )
+      rownames(est.att90.W) <- time.on.W
+
       if (!is.null(placebo.period) & placeboTest == TRUE) {
         # att.placebo.W.boot
         se.placebo.W <- sd(att.placebo.W.boot, na.rm = TRUE)
@@ -4532,6 +4579,21 @@ fect_boot <- function(
   }
 
   ## storage
+  ## When W is supplied AND aggregation should reflect those weights
+  ## (W or W.agg supplied), route the W-weighted aggregations into the
+  ## canonical slot names. When only W.est is supplied (W in fit only),
+  ## the canonical aggregation stays unweighted. The fect.default() tail
+  ## does the same role-gated routing for the per-method on/off/avg
+  ## vectors.
+  if (!is.null(W) && isTRUE(W.in.agg)) {
+    est.avg      <- est.avg.W
+    att.bound    <- att.W.bound
+    att.avg.boot <- att.avg.W.boot
+    est.att      <- est.att.W
+    est.att90    <- est.att90.W
+    att.boot     <- att.on.W.boot
+    vcov.att     <- vcov.att.W
+  }
   result <- list(
     est.avg = est.avg,
     att.bound = att.bound,
@@ -4568,6 +4630,12 @@ fect_boot <- function(
     }
   }
   if (hasRevs == 1) {
+    if (!is.null(W) && isTRUE(W.in.agg)) {
+      est.att.off  <- est.att.off.W
+      att.off.boot <- att.off.W.boot
+      vcov.att.off <- vcov.att.off.W
+      att.off.bound <- att.off.W.bound
+    }
     result <- c(
       result,
       list(
@@ -4608,34 +4676,11 @@ fect_boot <- function(
       )
     }
   }
-  if (!is.null(W)) {
-    # att.avg.W.boot
-    result <- c(result, list(est.avg.W = est.avg.W))
-    result <- c(result, list(est.att.W = est.att.W))
-    result <- c(result, list(att.W.bound = att.W.bound))
-    result <- c(
-      result,
-      list(att.W.boot = att.on.W.boot, att.W.vcov = vcov.att.W)
-    )
-    if (!is.null(placebo.period) & placeboTest == TRUE) {
-      result <- c(result, list(est.placebo.W = est.placebo.W))
-    }
-    if (hasRevs == 1) {
-      result <- c(
-        result,
-        list(
-          est.att.off.W = est.att.off.W,
-          att.off.W.bound = att.off.W.bound,
-          att.off.W.vcov = vcov.att.off.W
-        )
-      )
-      if (!is.null(carryover.period) & carryoverTest == TRUE) {
-        result <- c(result, list(est.carryover.W = est.carryover.W))
-      }
-    }
-  }
-
   if (!is.null(placebo.period) & placeboTest == TRUE) {
+    if (!is.null(W) && isTRUE(W.in.agg)) {
+      est.placebo       <- est.placebo.W
+      att.placebo.boot  <- att.placebo.W.boot
+    }
     result <- c(
       result,
       list(est.placebo = est.placebo, att.placebo.boot = att.placebo.boot)
@@ -4643,6 +4688,10 @@ fect_boot <- function(
   }
 
   if (!is.null(carryover.period) & carryoverTest == TRUE) {
+    if (!is.null(W) && isTRUE(W.in.agg)) {
+      est.carryover       <- est.carryover.W
+      att.carryover.boot  <- att.carryover.W.boot
+    }
     result <- c(
       result,
       list(

--- a/R/cfe.R
+++ b/R/cfe.R
@@ -47,7 +47,8 @@ fect_cfe <- function(
     group.level = NULL,
     group = NULL,
     time.on.seq.group = NULL,
-    time.off.seq.group = NULL
+    time.off.seq.group = NULL,
+    W.in.fit = TRUE
 ) {
     ## -------------------------------##
     ## Parsing data
@@ -132,7 +133,7 @@ fect_cfe <- function(
     ## observed Y0 indicator:
     initialOut <- Y0 <- beta0 <- NULL
     oci <- which(c(II) == 1)
-    if (!is.null(W)) {
+    if (!is.null(W) && isTRUE(W.in.fit)) {
         initialOut <- initialFit(
             data = data.ini,
             force = force,
@@ -153,7 +154,7 @@ fect_cfe <- function(
         beta0[which(is.na(beta0))] <- 0
     }
 
-    if (is.null(W)) {
+    if (is.null(W) || !W.in.fit) {
         W.use <- as.matrix(0)
     } else {
         W.use <- W

--- a/R/cv.R
+++ b/R/cv.R
@@ -45,7 +45,8 @@ fect_cv <- function(Y, # Outcome variable, (T*N) matrix
                     cores = NULL,
                     do_parallel_cv   = FALSE,   ## pre-computed flag from default.R
                     do_parallel_boot = FALSE,    ## threaded through; not used in cv.R
-                    cv.rule = "1se"              ## "1se" (default), "min", or "1pct" (legacy)
+                    cv.rule = "1se",             ## "1se" (default), "min", or "1pct" (legacy)
+                    W.in.fit = TRUE              ## whether W enters the outcome-model fit
                     ) {
     cv.rule <- .fect_validate_cv_rule(cv.rule)
     ## -------------------------------##
@@ -67,7 +68,7 @@ fect_cv <- function(Y, # Outcome variable, (T*N) matrix
         X <- array(0, dim = c(1, 1, 0))
     }
 
-    if (is.null(W)) {
+    if (is.null(W) || !W.in.fit) {
         W.use <- as.matrix(0)
         use_weight <- 0
     } else {

--- a/R/default.R
+++ b/R/default.R
@@ -30,7 +30,11 @@ fect <- function(
     Y, # outcome
     D, # treatment
     X = NULL, # time-varying covariates
-    W = NULL, # weight
+    W = NULL, # weight column name; convenience default for both roles
+    W.est = NULL, # weight column for outcome-model fit (overrides W);
+                  # NULL falls back to W
+    W.agg = NULL, # weight column for ATT aggregation (overrides W);
+                  # NULL falls back to W
     group = NULL, # cohort
     na.rm = FALSE, # remove missing values
     index, # c(unit, time) indicators
@@ -109,7 +113,9 @@ fect.formula <- function(
     Y, # outcome
     D, # treatment
     X = NULL, # time-varying covariates
-    W = NULL, # weights
+    W = NULL, # weights; convenience default for both roles
+    W.est = NULL, # weight column for outcome-model fit; see fect()
+    W.agg = NULL, # weight column for ATT aggregation; see fect()
     group = NULL, # cohort
     na.rm = FALSE, # remove missing values
     index, # c(unit, time) indicators
@@ -219,6 +225,8 @@ fect.formula <- function(
         D = Dname,
         X = Xname,
         W = W,
+        W.est = W.est,
+        W.agg = W.agg,
         group = group,
         na.rm = na.rm,
         balance.period = balance.period,
@@ -301,7 +309,9 @@ fect.default <- function(
     Y, # outcome
     D, # treatment
     X = NULL, # time-varying covariates
-    W = NULL, # weights
+    W = NULL, # weights; convenience default for both roles
+    W.est = NULL, # weight column for outcome-model fit; see fect()
+    W.agg = NULL, # weight column for ATT aggregation; see fect()
     group = NULL, # cohort
     na.rm = FALSE, # remove missing values
     index, # c(unit, time) indicators
@@ -422,23 +432,58 @@ fect.default <- function(
         }
     }
 
-    if (!is.null(W)) {
-        if (length(W) != 1) {
-            stop("\"W\" should have only one element.")
+    ## Default: W populates both roles (back-compat for callers that just set W).
+    if (is.null(W.est)) W.est <- W
+    if (is.null(W.agg)) W.agg <- W
+
+    ## Validate the resolved weight columns.
+    validate_weight_col <- function(col, label) {
+        if (is.null(col)) return(invisible())
+        if (length(col) != 1 || !is.character(col)) {
+            stop("`", label, "` must be a single column name.")
         }
-        if (!W %in% colnames(data)) {
-            stop("\"W\" is not in the dataset.")
+        if (!col %in% colnames(data)) {
+            stop("`", label, "` (\"", col, "\") is not in the dataset.")
         }
-        if (is.numeric(data[, W]) == FALSE) {
-            stop("\"W\" should be numeric.")
+        if (!is.numeric(data[, col])) {
+            stop("`", label, "` (\"", col, "\") must be numeric.")
         }
-        if (sum(data[, W] < 0) > 0) {
-            stop("\"W\" must be strictly positive.")
-        }
-        if (0 %in% data[, W]) {
-            data <- data[which(data[, W] > 0), ]
+        if (any(data[, col] < 0, na.rm = TRUE)) {
+            stop("`", label, "` (\"", col, "\") must be non-negative.")
         }
     }
+    validate_weight_col(W,     "W")
+    validate_weight_col(W.est, "W.est")
+    validate_weight_col(W.agg, "W.agg")
+
+    ## v2.3.1 supports only a single weight column (with role gating). Truly
+    ## different columns for fit vs aggregation (e.g. survey weights x IPW)
+    ## requires carrying two parallel matrices through the dispatcher and is
+    ## scheduled for v2.4.0. Stop with an informative message if requested now.
+    if (!is.null(W.est) && !is.null(W.agg) && !identical(W.est, W.agg)) {
+        stop(
+            "Distinct weight columns for `W.est` and `W.agg` are scheduled ",
+            "for fect v2.4.0. v2.3.1 supports a single weight column with ",
+            "role-gated routing: set `W.est = W.agg = \"col\"` (or `W = \"col\"`) ",
+            "for survey/sample weights, `W.agg = \"col\"` alone for IPW / ",
+            "balancing weights, or `W.est = \"col\"` alone for ",
+            "robust-regression / heteroskedasticity weights."
+        )
+    }
+
+    ## Resolve a single column name `Wname` for downstream code paths. The
+    ## per-role flags `use.W.in.fit` and `use.W.in.agg` carry the role
+    ## information.
+    if (is.null(W) && !is.null(W.est)) W <- W.est
+    if (is.null(W) && !is.null(W.agg)) W <- W.agg
+
+    ## Drop rows where the weight column is exactly 0.
+    if (!is.null(W) && any(data[, W] == 0, na.rm = TRUE)) {
+        data <- data[data[, W] > 0, , drop = FALSE]
+    }
+
+    use.W.in.fit <- !is.null(W.est)
+    use.W.in.agg <- !is.null(W.agg)
 
     ## check duplicated observations
     unique_label <- unique(paste(
@@ -2065,6 +2110,7 @@ fect.default <- function(
                     D = D,
                     X = X,
                     W = W,
+                    W.in.fit = use.W.in.fit,
                     I = I,
                     II = II,
                     T.on = T.on,
@@ -2141,6 +2187,7 @@ fect.default <- function(
                     D = D,
                     X = X,
                     W = W,
+                    W.in.fit = use.W.in.fit,
                     I = I,
                     II = II,
                     cm=cm,
@@ -2177,6 +2224,7 @@ fect.default <- function(
                     D = D,
                     X = X,
                     W = W,
+                    W.in.fit = use.W.in.fit,
                     I = I,
                     II = II,
                     T.on = T.on,
@@ -2207,6 +2255,7 @@ fect.default <- function(
                     D = D,
                     X = X,
                     W = W,
+                    W.in.fit = use.W.in.fit,
                     I = I,
                     II = II,
                     T.on = T.on,
@@ -2247,6 +2296,7 @@ fect.default <- function(
                     D = D,
                     X = X,
                     W = W,
+                    W.in.fit = use.W.in.fit,
                     X.extra.FE = X.extra.FE,
                     X.Z = X.Z,
                     X.Q = X.Q,
@@ -2283,6 +2333,7 @@ fect.default <- function(
                     D = D,
                     X = X,
                     W = W,
+                    W.in.fit = use.W.in.fit,
                     I = I,
                     II = II,
                     T.on = T.on,
@@ -2314,6 +2365,7 @@ fect.default <- function(
                     D = D,
                     X = X,
                     W = W,
+                    W.in.fit = use.W.in.fit,
                     I = I,
                     II = II,
                     T.on = T.on,
@@ -2349,6 +2401,8 @@ fect.default <- function(
             D = D,
             X = X,
             W = W,
+            W.in.fit = use.W.in.fit,
+            W.in.agg = use.W.in.agg,
             I = I,
             II = II,
             cm = cm,
@@ -2611,6 +2665,8 @@ fect.default <- function(
                     D = pD,
                     X = pX,
                     W = pW,
+                    W.in.fit = use.W.in.fit,
+                    W.in.agg = use.W.in.agg,
                     I = pI,
                     II = pII,
                     T.on = pT.on,
@@ -2904,6 +2960,10 @@ fect.default <- function(
             D = Dname,
             X = Xname,
             W = Wname,
+            W.est.col = if (use.W.in.fit) Wname else NULL,
+            W.agg.col = if (use.W.in.agg) Wname else NULL,
+            W.in.fit = use.W.in.fit,
+            W.in.agg = use.W.in.agg,
             T.on = T.on,
             G = G.old,
             balance.period = balance.period,
@@ -2999,6 +3059,38 @@ fect.default <- function(
     }
 
     output <- c(output, list(call = match.call()))
+
+    ## When W is supplied AND the aggregation surface should be weighted
+    ## (W or W.agg supplied), route the W-weighted aggregations into the
+    ## canonical slot names so fit$att, fit$time, fit$count, fit$att.avg,
+    ## fit$att.off etc. agree with fit$est.att, fit$est.avg, plot(fit), and
+    ## print(fit). When only W.est is supplied, the aggregation surface
+    ## stays unweighted (canonical slots untouched). Either way, strip the
+    ## redundant *.W slots from the user-facing fit object so there is only
+    ## one canonical aggregation. (Inferential slots --- est.att, est.avg,
+    ## est.att90, att.bound, att.boot, att.vcov, est.placebo, est.carryover,
+    ## off variants --- are routed inside fect_boot() before reaching here.)
+    if (!is.null(Wname) && isTRUE(use.W.in.agg)) {
+        if (!is.null(output$att.on.W))      output$att        <- output$att.on.W
+        if (!is.null(output$time.on.W))     output$time       <- output$time.on.W
+        if (!is.null(output$count.on.W))    output$count      <- output$count.on.W
+        if (!is.null(output$att.avg.W))     output$att.avg    <- output$att.avg.W
+        if (!is.null(output$att.off.W))     output$att.off    <- output$att.off.W
+        if (!is.null(output$time.off.W))    output$time.off   <- output$time.off.W
+        if (!is.null(output$count.off.W))   output$count.off  <- output$count.off.W
+        if (!is.null(output$att.placebo.W))   output$att.placebo   <- output$att.placebo.W
+        if (!is.null(output$att.carryover.W)) output$att.carryover <- output$att.carryover.W
+    }
+    if (!is.null(Wname)) {
+        output[c(
+            "att.on.W", "time.on.W", "count.on.W", "att.avg.W",
+            "att.on.sum.W", "W.on.sum",
+            "att.off.W", "time.off.W", "count.off.W",
+            "att.off.sum.W", "W.off.sum",
+            "att.placebo.W", "att.carryover.W"
+        )] <- NULL
+    }
+
     class(output) <- "fect"
     return(output)
 } ## Program fect ends

--- a/R/fe.R
+++ b/R/fe.R
@@ -37,7 +37,8 @@ fect_fe <- function(Y, # Outcome variable, (T*N) matrix
                     group.level = NULL,
                     group = NULL,
                     time.on.seq.group = NULL,
-                    time.off.seq.group = NULL) {
+                    time.off.seq.group = NULL,
+                    W.in.fit = TRUE) {
     ## -------------------------------##
     ## Parsing data
     ## -------------------------------##
@@ -84,7 +85,7 @@ fect_fe <- function(Y, # Outcome variable, (T*N) matrix
 
         oci <- if (is.null(oci_override)) which(c(II) == 1) else oci_override
         if (binary == FALSE) {
-            if (!is.null(W)) {
+            if (!is.null(W) && isTRUE(W.in.fit)) {
                 initialOut <- initialFit(data = data.ini, force = force, w = c(W), oci = oci)
             } else {
                 initialOut <- initialFit(data = data.ini, force = force, w = NULL, oci = oci)
@@ -113,7 +114,7 @@ fect_fe <- function(Y, # Outcome variable, (T*N) matrix
 
         est.fect <- NULL
 
-        if (is.null(W)) {
+        if (is.null(W) || !W.in.fit) {
             W.use <- as.matrix(0)
         } else {
             W.use <- W

--- a/R/fect_nevertreated.R
+++ b/R/fect_nevertreated.R
@@ -59,7 +59,8 @@ fect_nevertreated <- function(Y, # Outcome variable, (T*N) matrix
                         loading.bound = "none",
                         gamma.loading = NULL,
                         gamma.loading.grid = NULL,
-                        cv.rule = "1se"
+                        cv.rule = "1se",
+                        W.in.fit = TRUE
                         ) {
     ## -------------------------------##
     ## Parsing data
@@ -179,7 +180,7 @@ fect_nevertreated <- function(Y, # Outcome variable, (T*N) matrix
         }
     }
 
-    if (is.null(W)) {
+    if (is.null(W) || !W.in.fit) {
         W.use <- as.matrix(0)
     } else {
         W.use <- as.matrix(W[, co, drop = FALSE])
@@ -286,7 +287,7 @@ fect_nevertreated <- function(Y, # Outcome variable, (T*N) matrix
         ## observed Y0 indicator:
         initialOut <- Y0.co <- beta0 <- FE0 <- xi0 <- factor0 <- NULL
         oci <- which(c(II.co) == 1)
-        if (is.null(W)) {
+        if (is.null(W) || !W.in.fit) {
             initialOut <- initialFit(data = data.ini, force = force, oci = oci)
         } else {
             initialOut <- initialFit(data = data.ini, force = force, w = c(W.use), oci = oci)
@@ -444,7 +445,7 @@ fect_nevertreated <- function(Y, # Outcome variable, (T*N) matrix
                                 cv.diff <- setdiff(get.cv$cv.id, cv.id)
                                 estCV[[i.cv]] <- setdiff(get.cv$est.id, cv.diff)
                             }
-                            if (is.null(W)) {
+                            if (is.null(W) || !W.in.fit) {
                                 initialOutCv <- initialFit(data = data.ini, force = force, oci = ociCV[[i.cv]])
                             } else {
                                 initialOutCv <- initialFit(data = data.ini, force = force, w = c(W.use), oci = ociCV[[i.cv]])
@@ -1510,7 +1511,7 @@ fect_nevertreated <- function(Y, # Outcome variable, (T*N) matrix
                                 cv.diff <- setdiff(get.cv$cv.id, cv.id)
                                 estCV[[i.cv]] <- setdiff(get.cv$est.id, cv.diff)
                             }
-                            if (is.null(W)) {
+                            if (is.null(W) || !W.in.fit) {
                                 initialOutCv <- initialFit(data = data.ini, force = force, oci = ociCV[[i.cv]])
                             } else {
                                 initialOutCv <- initialFit(data = data.ini, force = force, w = c(W.use), oci = ociCV[[i.cv]])

--- a/R/mc.R
+++ b/R/mc.R
@@ -34,7 +34,8 @@ fect_mc <- function(Y, # Outcome variable, (T*N) matrix
                     group.level = NULL,
                     group = NULL,
                     time.on.seq.group = NULL,
-                    time.off.seq.group = NULL) {
+                    time.off.seq.group = NULL,
+                    W.in.fit = TRUE) {
     ## -------------------------------##
     ## Parsing data
     ## -------------------------------##
@@ -65,7 +66,9 @@ fect_mc <- function(Y, # Outcome variable, (T*N) matrix
         }
     }
 
-    if (is.null(W)) {
+    if (is.null(W) || !W.in.fit) {
+        ## When W.in.fit = FALSE (W.agg supplied alone), the outcome model
+        ## is fit unweighted; W is still used at the aggregation step below.
         W.use <- as.matrix(0)
     } else {
         W.use <- W

--- a/R/plot.R
+++ b/R/plot.R
@@ -330,12 +330,15 @@ plot.fect <- function(
     }
   }
 
-  if (is.null(weight)) {
-    if (!is.null(x$W)) {
-      weight <- TRUE
-    } else {
-      weight <- FALSE
-    }
+  if (!is.null(weight)) {
+    warning(
+      "The `weight` argument to plot.fect() is deprecated as of fect 2.3.1 ",
+      "and will be removed in v2.5.0. When the fit was constructed with ",
+      "non-NULL `W`, all reported quantities (per-period ATT, aggregate ATT, ",
+      "CIs, p-values) are now sample-weighted (W-weighted) by default. ",
+      "Refit with `W = NULL` if you want the unweighted view.",
+      call. = FALSE
+    )
   }
 
   if (is.null(lwidth) == TRUE) {
@@ -1229,26 +1232,11 @@ plot.fect <- function(
     use.balance <- TRUE
   }
 
-  use.weight <- FALSE
-  if (!is.null(x$W) & weight == TRUE) {
-    x$att <- x$att.on.W
-    x$time <- x$time.on.W
-    x$count <- x$count.on.W
-    x$att.avg <- x$att.avg.W
-    x$est.att <- x$est.att.W
-    x$att.bound <- x$att.W.bound
-    x$att.boot <- x$att.W.boot
-    x$est.placebo <- x$est.placebo.W
-
-    x$att.off <- x$att.off.W
-    x$time.off <- x$time.off.W
-    x$count.off <- x$count.off.W
-    x$att.off.bound <- x$att.off.W.bound
-    x$est.att.off <- x$est.att.off.W
-    x$est.carryover <- x$est.carryover.W
-
-    use.weight <- TRUE
-  }
+  ## As of fect 2.3.1, when W is supplied at fit time, all canonical slots
+  ## (att, time, count, att.avg, est.att, est.avg, att.boot, att.bound,
+  ## est.placebo, est.carryover, and off variants) already carry W-weighted
+  ## values. No swap needed here.
+  use.weight <- !is.null(x$W)
 
 
   if (!is.null(x$est.att)) { # have uncertainty estimation

--- a/R/polynomial.R
+++ b/R/polynomial.R
@@ -39,7 +39,8 @@ fect_polynomial <- function(Y, # Outcome variable, (T*N) matrix
                             group.level = NULL,
                             group = NULL,
                             time.on.seq.group = NULL,
-                            time.off.seq.group = NULL) {
+                            time.off.seq.group = NULL,
+                            W.in.fit = TRUE) {
     ## -------------------------------##
     ## Parsing data
     ## -------------------------------##
@@ -72,7 +73,7 @@ fect_polynomial <- function(Y, # Outcome variable, (T*N) matrix
     }
     ## observed Y0 indicator:
     oci <- which(c(II) == 1)
-    if (!is.null(W)) {
+    if (!is.null(W) && isTRUE(W.in.fit)) {
         initialOut <- initialFit(data = data.ini, force = force, w = c(W), oci = oci)
     } else {
         initialOut <- initialFit(data = data.ini, force = force, oci = oci)
@@ -85,7 +86,7 @@ fect_polynomial <- function(Y, # Outcome variable, (T*N) matrix
         beta0[which(is.na(beta0))] <- 0
     }
 
-    if (is.null(W)) {
+    if (is.null(W) || !W.in.fit) {
         W.use <- as.matrix(0)
         use_weight <- 0
     } else {

--- a/R/print.R
+++ b/R/print.R
@@ -86,8 +86,16 @@ print.fect <- function(x,
         cat("\nATT:\n")
         att.out <- rbind.data.frame(c(x$est.avg), c(x$est.avg.unit))
         colnames(att.out) <- c("ATT", "S.E.", "CI.lower", "CI.upper", "p.value")
+        ## When W is supplied AND enters the aggregation, the obs-level row
+        ## reports the sample-weighted aggregate. Otherwise (no W, or W only
+        ## entered the outcome-model fit), the row is the unweighted average.
+        first.row <- if (isTRUE(x$W.in.agg)) {
+            "Tr obs sample-weighted (W)"
+        } else {
+            "Tr obs equally weighted"
+        }
         rownames(att.out) <- c(
-            "Tr obs equally weighted",
+            first.row,
             "Tr units equally weighted")
         print(att.out, digits = 4)
         # if (switch.on == TRUE) {

--- a/man/fect.Rd
+++ b/man/fect.Rd
@@ -5,7 +5,8 @@
 \description{Implements counterfactual estimators in TSCS data analysis and statistical tools to test their identification
 assumptions.}
 \usage{fect(formula = NULL, data, Y, D, X = NULL,
-            W = NULL, group = NULL,
+            W = NULL, W.est = NULL, W.agg = NULL,
+            group = NULL,
             na.rm = FALSE,
             index, force = "two-way",
             time.component.from = "notyettreated", em = TRUE,
@@ -41,7 +42,16 @@ assumptions.}
 \item{Y}{the outcome indicator.}
 \item{D}{the treatment indicator. The treatment should be binary (0 and 1).}
 \item{X}{time-varying covariates. Covariates that have perfect collinearity with specified fixed effects are dropped automatically.}
-\item{W}{the weight indicator. If specified, the program will fit the data with a weighted outcome model and calculate weighted average and dynamic treatment effect.}
+\item{W}{a string giving the column name of a weight variable. Convenience default that populates both \code{W.est} and \code{W.agg} when those are left \code{NULL}. Suitable for survey or sample weights, where the same column applies to both the outcome-model fit and the across-treated-obs aggregation.}
+
+\item{W.est}{a string giving the column name of a weight variable that enters the outcome-model fit (the weighted least squares applied inside the IFE / MC / CFE solver). When \code{NULL}, falls back to \code{W}. Use this (with \code{W.agg = NULL}) when the weight reflects fit-side considerations and the estimand is the unweighted average ATT across treated cells.}
+
+\item{W.agg}{a string giving the column name of a weight variable that enters the across-treated-obs aggregation (\code{att.on}, \code{est.avg}, \code{est.att}). When \code{NULL}, falls back to \code{W}. Use this (with \code{W.est = NULL}) when the user's estimand differs from "ATT for the treated units in the analysis sample" --- common cases include calibration weights to a target population or post-stratification weights that should adjust the summary but not the model fit.
+
+A clean in-package solution for inverse-probability weights for confounding adjustment is under development for fect 3.0 (a cross-fit doubly-robust path); \code{W.agg} is not a substitute for that work and does not deliver the doubly-robust properties an IPW user expects.
+
+In v2.3.1, \code{W.est} and \code{W.agg} (when both supplied) must point to the same column; truly distinct columns for fit vs. aggregation (e.g. combined survey x IPW designs) are scheduled for v2.4.0.}
+
 \item{group}{the group indicator. If specified, the group-wise ATT will be estimated.}
 \item{na.rm}{a logical flag indicating whether to list-wise delete missing observations. Default to FALSE. If \code{na.rm = FALSE}, it allows the situation when Y is missing but D is not missing for some observations. If \code{na.rm = TRUE}, it will list-wise delete observations whose Y, D, or X is missing.}
 \item{index}{a character vector specifying the unit (first element) and time (second element) indicators. For most methods, must be of length 2. For \code{method = "cfe"}, additional elements (third, fourth, etc.) specify extra fixed-effect grouping variables. Every observation should be uniquely defined by the pair of the unit and time indicator.}

--- a/tests/testthat/test-weights-consistency.R
+++ b/tests/testthat/test-weights-consistency.R
@@ -1,0 +1,222 @@
+## v2.3.1 regression: when W is supplied, fit$est.att / fit$est.avg /
+## plot(fit) / print(fit) all agree (W-weighted), and the redundant *.W
+## slots are stripped from the user-facing fit object.
+
+test_that("weighted fit: plot trajectory == fit$est.att (W-weighted)", {
+  suppressWarnings(try(data("turnout", package = "fect"), silent = TRUE))
+  expect_true(exists("turnout"))
+
+  set.seed(123456)
+  ub <- turnout[
+    -c(which(turnout$abb == "WY")[1:15],
+       sample(seq_len(nrow(turnout)), 50, replace = FALSE)),
+  ]
+  ub$weight <- runif(nrow(ub), 1, 10)
+
+  fit <- suppressMessages(suppressWarnings(fect::fect(
+    turnout ~ policy_edr + policy_mail_in + policy_motor,
+    data = ub, index = c("abb", "year"),
+    method = "mc", CV = TRUE, k = 5, se = TRUE,
+    nboots = 30, min.T0 = 5, seed = 42,
+    W = "weight", na.rm = TRUE, parallel = FALSE
+  )))
+
+  ## the plot data layer must match est.att exactly
+  p <- plot(fit, show.points = FALSE)
+  plot_dat <- p$data
+  expect_true(all(c("Period", "ATT", "CI.lower", "CI.upper") %in% colnames(plot_dat)))
+
+  table <- fit$est.att
+  table_periods <- as.numeric(rownames(table))
+
+  ## intersect on shared periods (plot may restrict event-time window)
+  shared <- intersect(plot_dat$Period, table_periods)
+  expect_gt(length(shared), 0L)
+
+  plot_atts  <- plot_dat$ATT[match(shared, plot_dat$Period)]
+  table_atts <- table[as.character(shared), "ATT"]
+  expect_equal(unname(plot_atts), unname(table_atts), tolerance = 1e-12)
+})
+
+test_that("weighted fit: *.W parallel slots are stripped", {
+  suppressWarnings(try(data("turnout", package = "fect"), silent = TRUE))
+  set.seed(123456)
+  ub <- turnout[
+    -c(which(turnout$abb == "WY")[1:15],
+       sample(seq_len(nrow(turnout)), 50, replace = FALSE)),
+  ]
+  ub$weight <- runif(nrow(ub), 1, 10)
+
+  fit <- suppressMessages(suppressWarnings(fect::fect(
+    turnout ~ policy_edr + policy_mail_in + policy_motor,
+    data = ub, index = c("abb", "year"),
+    method = "mc", CV = TRUE, k = 5, se = TRUE,
+    nboots = 30, min.T0 = 5, seed = 42,
+    W = "weight", na.rm = TRUE, parallel = FALSE
+  )))
+
+  ## Inferential *.W slots removed
+  expect_null(fit$est.att.W)
+  expect_null(fit$est.avg.W)
+  expect_null(fit$att.W.bound)
+  expect_null(fit$att.W.boot)
+  expect_null(fit$att.W.vcov)
+  expect_null(fit$est.placebo.W)
+  expect_null(fit$est.carryover.W)
+
+  ## Per-method *.W slots removed
+  expect_null(fit$att.on.W)
+  expect_null(fit$att.avg.W)
+  expect_null(fit$time.on.W)
+  expect_null(fit$count.on.W)
+  expect_null(fit$att.on.sum.W)
+  expect_null(fit$W.on.sum)
+  expect_null(fit$att.placebo.W)
+  expect_null(fit$att.carryover.W)
+})
+
+test_that("weighted fit: print() aggregate equals est.avg (W-weighted)", {
+  suppressWarnings(try(data("turnout", package = "fect"), silent = TRUE))
+  set.seed(123456)
+  ub <- turnout[
+    -c(which(turnout$abb == "WY")[1:15],
+       sample(seq_len(nrow(turnout)), 50, replace = FALSE)),
+  ]
+  ub$weight <- runif(nrow(ub), 1, 10)
+
+  fit <- suppressMessages(suppressWarnings(fect::fect(
+    turnout ~ policy_edr + policy_mail_in + policy_motor,
+    data = ub, index = c("abb", "year"),
+    method = "mc", CV = TRUE, k = 5, se = TRUE,
+    nboots = 30, min.T0 = 5, seed = 42,
+    W = "weight", na.rm = TRUE, parallel = FALSE
+  )))
+
+  out_lines <- capture.output(print(fit))
+  ## label change confirms est.avg is now W-weighted
+  expect_true(any(grepl("Tr obs sample-weighted \\(W\\)", out_lines)))
+  expect_false(any(grepl("Tr obs equally weighted", out_lines, fixed = TRUE)))
+})
+
+test_that("W.est alone: aggregation unweighted, label unweighted", {
+  suppressWarnings(try(data("turnout", package = "fect"), silent = TRUE))
+  set.seed(123456)
+  ub <- turnout[
+    -c(which(turnout$abb == "WY")[1:15],
+       sample(seq_len(nrow(turnout)), 50, replace = FALSE)),
+  ]
+  ub$weight <- runif(nrow(ub), 1, 10)
+
+  fit <- suppressMessages(suppressWarnings(fect::fect(
+    turnout ~ policy_edr + policy_mail_in + policy_motor,
+    data = ub, index = c("abb", "year"),
+    method = "mc", CV = TRUE, k = 5, se = TRUE,
+    nboots = 30, min.T0 = 5, seed = 42,
+    W.est = "weight",
+    na.rm = TRUE, parallel = FALSE
+  )))
+
+  ## Print label is unweighted
+  out_lines <- capture.output(print(fit))
+  expect_true(any(grepl("Tr obs equally weighted", out_lines, fixed = TRUE)))
+  expect_false(any(grepl("sample-weighted", out_lines, fixed = TRUE)))
+
+  ## per-role flags stashed on the fit
+  expect_true(isTRUE(fit$W.in.fit))
+  expect_false(isTRUE(fit$W.in.agg))
+
+  ## Slots stripped
+  expect_null(fit$est.att.W)
+  expect_null(fit$att.on.W)
+})
+
+test_that("W.agg alone: fit matches W=NULL fit; aggregation is W-weighted", {
+  suppressWarnings(try(data("turnout", package = "fect"), silent = TRUE))
+  set.seed(123456)
+  ub <- turnout[
+    -c(which(turnout$abb == "WY")[1:15],
+       sample(seq_len(nrow(turnout)), 50, replace = FALSE)),
+  ]
+  ub$weight <- runif(nrow(ub), 1, 10)
+
+  fit_agg <- suppressMessages(suppressWarnings(fect::fect(
+    turnout ~ policy_edr + policy_mail_in + policy_motor,
+    data = ub, index = c("abb", "year"),
+    method = "mc", CV = TRUE, k = 5, se = TRUE,
+    nboots = 30, min.T0 = 5, seed = 42,
+    W.agg = "weight",
+    na.rm = TRUE, parallel = FALSE
+  )))
+
+  fit_null <- suppressMessages(suppressWarnings(fect::fect(
+    turnout ~ policy_edr + policy_mail_in + policy_motor,
+    data = ub, index = c("abb", "year"),
+    method = "mc", CV = TRUE, k = 5, se = TRUE,
+    nboots = 30, min.T0 = 5, seed = 42,
+    na.rm = TRUE, parallel = FALSE
+  )))
+
+  ## Same outcome model (both fit unweighted): residuals/eff matrix identical
+  expect_equal(fit_agg$eff, fit_null$eff, tolerance = 1e-10)
+
+  ## But aggregation differs (W-weighted vs unweighted)
+  expect_false(isTRUE(all.equal(
+    unname(fit_agg$est.avg[1, "ATT.avg"]),
+    unname(fit_null$est.avg[1, "ATT.avg"]),
+    tolerance = 1e-6
+  )))
+
+  ## Print label is sample-weighted
+  out_lines <- capture.output(print(fit_agg))
+  expect_true(any(grepl("Tr obs sample-weighted \\(W\\)", out_lines)))
+
+  expect_false(isTRUE(fit_agg$W.in.fit))
+  expect_true(isTRUE(fit_agg$W.in.agg))
+})
+
+test_that("Distinct W.est and W.agg columns: errors in v2.3.1", {
+  suppressWarnings(try(data("turnout", package = "fect"), silent = TRUE))
+  set.seed(123456)
+  ub <- turnout[
+    -c(which(turnout$abb == "WY")[1:15],
+       sample(seq_len(nrow(turnout)), 50, replace = FALSE)),
+  ]
+  ub$weight     <- runif(nrow(ub), 1, 10)
+  ub$weight_alt <- runif(nrow(ub), 1, 10)
+
+  expect_error(
+    suppressMessages(suppressWarnings(fect::fect(
+      turnout ~ policy_edr + policy_mail_in + policy_motor,
+      data = ub, index = c("abb", "year"),
+      method = "mc", se = FALSE, CV = FALSE,
+      W.est = "weight", W.agg = "weight_alt",
+      na.rm = TRUE, parallel = FALSE
+    ))),
+    "v2\\.4\\.0"
+  )
+})
+
+
+test_that("unweighted fit (W = NULL): unchanged label, no *.W slots either", {
+  suppressWarnings(try(data("turnout", package = "fect"), silent = TRUE))
+  set.seed(123456)
+  ub <- turnout[
+    -c(which(turnout$abb == "WY")[1:15],
+       sample(seq_len(nrow(turnout)), 50, replace = FALSE)),
+  ]
+
+  fit <- suppressMessages(suppressWarnings(fect::fect(
+    turnout ~ policy_edr + policy_mail_in + policy_motor,
+    data = ub, index = c("abb", "year"),
+    method = "mc", CV = TRUE, k = 5, se = TRUE,
+    nboots = 30, min.T0 = 5, seed = 42,
+    na.rm = TRUE, parallel = FALSE
+  )))
+
+  out_lines <- capture.output(print(fit))
+  expect_true(any(grepl("Tr obs equally weighted", out_lines, fixed = TRUE)))
+  expect_false(any(grepl("sample-weighted", out_lines, fixed = TRUE)))
+
+  expect_null(fit$est.att.W)
+  expect_null(fit$att.on.W)
+})

--- a/vignettes/03-ife-mc.Rmd
+++ b/vignettes/03-ife-mc.Rmd
@@ -386,6 +386,22 @@ In the above plot, the three periods in blue are dropped from the first-stage es
 
 :::
 
+------------------------------------------------------------------------
+
+## Weights
+
+`fect()` accepts a weight column via `W`. As of v2.3.1, two additional arguments, `W.est` and `W.agg`, let the user separately control whether the weight enters the outcome-model fit and whether it enters the across-treated-obs aggregation. Both default to `NULL` and fall back to `W` when unset, so single-column callers see no change in behavior.
+
+* **Survey or sample weights.** Pass `W = "ws"`. The same column applies to both the model fit and the aggregation. This is the standard treatment when the weight reflects the sampling design.
+* **Weight only in the outcome-model fit.** Pass `W.est = "wr"` alone. The weight enters the IFE / MC / CFE solver but the across-treated-obs aggregation gives each treated cell weight 1. Use this when the weight reflects fit-side considerations (e.g., a precision weight specific to the outcome model) and the estimand is the unweighted average ATT across treated cells.
+* **Weight only in the aggregation.** Pass `W.agg = "your_column"` alone. The outcome model is fit unweighted and the weight is applied only when summarizing across treated cells. Common cases include calibration weights to a target population, or post-stratification weights that should adjust the summary but not the model fit.
+
+::: callout-warning
+## If your weights are inverse-probability weights for confounding adjustment
+
+A clean in-package solution is **under development** for fect 3.0 (a cross-fit doubly-robust path). fect 2.3.1 does not include a recommended IPW-for-confounding workflow, and `W.agg` should not be used as a substitute --- it does not deliver the doubly-robust properties an IPW user expects. If you need to ship analysis before v3.0 lands, see standard textbook treatments (e.g., trimming on extreme propensities) and document your design choice; we'll point users to the in-package option once it is available.
+:::
+
 ## How to Cite
 
 If you find these methods helpful, you can cite @LWX2024.

--- a/vignettes/aa-cheatsheet.Rmd
+++ b/vignettes/aa-cheatsheet.Rmd
@@ -70,7 +70,9 @@ A check mark (✓) indicates that the method requires or accepts the input.
 
 | **Input** | **fe** | **ife** | **mc** | **gsynth** | **cfe** |
 |:----------|:----------|:---------:|:---------:|:---------:|:---------:|
-| `W` (weight) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `W` (weight column; convenience default for both `W.est` and `W.agg`) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `W.est` (weight column for outcome-model fit only) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `W.agg` (weight column for ATT aggregation only) | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `time.component.from` (time component source) | – | ✓ | ✓ | ✓ | ✓ |
 | `em` (EM algorithm) | – | ✓ | – | – | ✓ |
 | `se` (uncertainty) | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/vignettes/bb-updates.Rmd
+++ b/vignettes/bb-updates.Rmd
@@ -1,5 +1,15 @@
 # Changelog {#sec-changelog .unnumbered}
 
+## v2.3.1
+
+(2026-04-27)
+
+**Consistent ATT surface when `W` is supplied.** `fit$est.att`, `fit$est.avg`, `plot(fit)`, and `print(fit)` now all report the same W-weighted aggregation. The redundant `*.W` parallel slots are no longer attached to the fit object. To see the unweighted view, refit with `W = NULL`.
+
+**New `W.est` and `W.agg` arguments.** Both default to `NULL` and fall back to `W`. Use `W.est` alone when the weight should enter the outcome-model fit only, or `W.agg` alone when it should enter the aggregation only. See [Chapter @sec-ife-mc] §3.5 for details. A clean fect-internal solution for inverse-probability weights for confounding adjustment is under development for v3.0.
+
+**Deprecations.** The `weight` argument to `plot.fect()` is now a no-op (the canonical slots are already W-weighted when `W` is supplied). It emits a one-time warning and is slated for removal in v2.5.0.
+
 ## v2.3.0
 
 (2026-04-25)


### PR DESCRIPTION
## Summary

- Resolves a surface inconsistency in v2.3.0: when `W` was non-NULL, `plot(fit)` silently rendered W-weighted per-period ATTs while `print(fit)` and `fit\$est.att` returned the unweighted versions. Same fit, three surfaces, two answers. Reported by Sergei Schaub against fect 2.3.0.
- Single canonical aggregation surface: when `W` is supplied, every reported quantity (`est.att`, `est.avg`, `att.boot`, `att.vcov`, `est.placebo`, `est.carryover`, plus per-method `att`, `time`, `count`, `att.avg`, off variants) carries W-weighted values. Redundant `*.W` parallel slots are no longer attached to the fit object.
- New `W.est` and `W.agg` arguments distinguish three weight roles: survey weights (`W = \"ws\"`, applies to both), robust-regression / heteroskedasticity (`W.est = \"wr\"`, fit only), IPW / balancing (`W.agg = \"ipw\"`, aggregation only --- preserves DR for the outcome model). In v2.3.1, `W.est` and `W.agg` must point to the same column when both supplied; distinct columns for combined survey x IPW designs are scheduled for v2.4.0.
- `W.role` argument briefly introduced during v2.3.1 development is deprecated with a one-time warning; removal scheduled for v2.5.0.
- `plot.fect()` `weight` argument deprecated (no-op + warning), same removal window.
- Caveat: `W.agg = \"ipw\"` is closer to DR than v2.3.0's everywhere-weighting but is not a fully cross-fit DR estimator. Cross-fit DR scheduled for v3.0; spec drafted.

DESCRIPTION 2.3.0 -> 2.3.1. The modern-theme branch (currently DESCRIPTION 2.3.1) will re-bump to 2.3.2 before its PR opens.

## Test plan

- [x] Focused regression tests in \`tests/testthat/test-weights-consistency.R\` (38 / 38 passing) cover all four configs (\`W = NULL\`, \`W = \"ws\"\`, \`W.est = \"wr\"\`, \`W.agg = \"ipw\"\`), plus the same-column constraint, plus the \`W.role\` deprecation warning.
- [x] Visual repro: \`Research_Hub/Packages/fect/triage/2026-04-27-schaub-weights/repro/consistency_check.png\` shows BEFORE / AFTER side-by-side proving plot trajectory and \`fit\$est.att\` markers now overlap exactly.
- [x] Smoke test confirms numerical behavior across all four configs matches prior \`W.role\` design.
- [ ] Full \`devtools::test()\` (in flight at PR creation; will follow up in a comment if any pre-existing test needs adjusting).