### PR TITLE
fix(boot,plot,diagtest): PSOCK retry + carryover.rm slot + APTT vignette (v2.3.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: fect
 Type: Package
 Title: Fixed Effects Counterfactual Estimators
-Version: 2.3.2
+Version: 2.3.3
 Date: 2026-04-28
 Authors@R: 
     c(person("Licheng", "Liu", , "lichengl@stanford.edu", role = c("aut")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,31 @@
 <!-- markdownlint-disable MD025 -->
+# fect 2.3.3 (development)
+
+## Bug fixes
+
+* Fix `"incorrect number of dimensions"` crash in `diagtest()` that
+  surfaced intermittently with `parallel = TRUE` + small `nboots`.
+  Two layers: (a) `R/diagtest.R` now uses `drop = FALSE` when filtering
+  bootstrap columns by all-non-NA, so a single surviving column stays
+  a matrix; (b) the bootstrap parallel path in `R/boot.R` now builds
+  the PSOCK cluster via `parallelly::makeClusterPSOCK(rscript_libs =
+  .libPaths())` (the same robust pattern used by the CV path),
+  wrapped in a 3-attempt retry-with-backoff. If `doParallel` cluster
+  init exhausts retries the bootstrap now degrades to sequential
+  rather than crashing.
+* `carryover.rm` is now stored on the fit object. `plot.fect()` no
+  longer reads it from `as.list(x$call)$carryover.rm` (which silently
+  gave the wrong K under `do.call()`, programmatic wrappers, or any
+  call-rewriting code path). Behaviorally a no-op for fits built via
+  named-argument `fect(...)`; correct under any other construction.
+
+## Documentation
+
+* Chapter 2 §Other estimands gains a worked example for post-hoc
+  estimands derived from the imputed potential-outcome surface,
+  showing APTT (Chen & Roth 2024) with bootstrap CIs from the
+  existing fit slots. Issue #126 (ajunquera).
+
 # fect 2.3.2 (development)
 
 ## Modern visual defaults for `plot.fect()` (visual breaking change)

--- a/R/boot.R
+++ b/R/boot.R
@@ -1564,16 +1564,34 @@ fect_boot <- function(
     }
 
     run_dopar_retry <- function(idx, workers) {
-      cl <- parallel::makePSOCKcluster(workers)
+      ## Build the PSOCK cluster via the package helper, which bakes
+      ## .libPaths() into worker startup (rscript_libs) — eliminating
+      ## the post-construction `clusterCall(.libPaths)` race that
+      ## occasionally killed a worker before iter 1 in mixed CV+boot
+      ## test runs (E.6 in test-cv-parallel.R). Retry-with-backoff on
+      ## socket-init failure; shrink workers between attempts.
+      cl <- NULL
+      init_err <- NULL
+      try_workers <- max(1L, as.integer(workers))
+      for (attempt in seq_len(3L)) {
+        cl <- tryCatch(
+          .fect_make_future_cluster(try_workers),
+          error = function(e) {
+            init_err <<- e
+            NULL
+          }
+        )
+        if (!is.null(cl)) break
+        Sys.sleep(0.5 * attempt)
+        try_workers <- max(1L, try_workers - 1L)
+      }
+      if (is.null(cl)) {
+        stop("PSOCK cluster initialization failed: ",
+             conditionMessage(init_err))
+      }
       on.exit({
         try(parallel::stopCluster(cl), silent = TRUE)
       }, add = TRUE)
-      ## Propagate parent .libPaths() so PSOCK workers can find fect
-      ## (and other user-installed packages) regardless of how the
-      ## parent R session was launched (e.g. Quarto render).
-      parent_libs <- .libPaths()
-      try(parallel::clusterCall(cl, function(p) .libPaths(p),
-                                p = parent_libs), silent = TRUE)
       doParallel::registerDoParallel(cl)
       suppressWarnings(foreach(
         j = idx,
@@ -1638,7 +1656,23 @@ fect_boot <- function(
           workers <- max(1L, min(raw_cores, 8L))
         }
         workers <- max(1L, as.integer(workers))
-        run_dopar_retry(1:nboots, workers)
+        ## If doParallel ALSO can't bring up a cluster (cluster-init
+        ## storm after CV plan teardown, etc.), degrade to sequential
+        ## rather than letting fect() die. Bootstrap completes with
+        ## reduced throughput; downstream aggregation is unaffected.
+        tryCatch(
+          run_dopar_retry(1:nboots, workers),
+          error = function(e2) {
+            warning(
+              paste0(
+                "doParallel backend also failed (",
+                conditionMessage(e2),
+                "). Falling back to sequential bootstrap."
+              )
+            )
+            lapply(seq_len(nboots), quiet_nonpara)
+          }
+        )
       }
     )
 

--- a/R/default.R
+++ b/R/default.R
@@ -2982,6 +2982,10 @@ fect.default <- function(
             placebo.period = placebo.period,
             carryoverTest = carryoverTest,
             carryover.period = carryover.period,
+            ## Stored on the fit object so plot logic does not need to
+            ## re-parse `x$call` — robust under do.call(), positional
+            ## args, and call-rewriting wrappers.
+            carryover.rm = carryover.rm,
             unit.type = unit.type,
             obs.missing = obs.missing,
             obs.missing.balance = obs.missing.balance,

--- a/R/diagtest.R
+++ b/R/diagtest.R
@@ -63,7 +63,12 @@ diagtest <- function(
         max.pre.periods <- sum(x$time <= 0)
         pre.pos <- intersect(c(1:dim(x$pre.att.boot)[1]), which(x$time %in% pre.periods))
         res_boot <- x$pre.att.boot
-        res_boot <- res_boot[, which(apply(!is.na(res_boot), 2, all))]
+        ## Preserve matrix shape when only one bootstrap column passes
+        ## the all-non-NA filter; otherwise res_boot collapses to a
+        ## vector and the row-subset on the next branch errors with
+        ## "incorrect number of dimensions".
+        res_boot <- res_boot[, which(apply(!is.na(res_boot), 2, all)),
+                             drop = FALSE]
         if (length(pre.pos) == max.pre.periods) {
             pre.pos <- pre.pos[-1]
             #message("Cannot use full pre-treatment periods in F-test. The first period is removed.\n")
@@ -138,7 +143,12 @@ diagtest <- function(
         }
 
         res_boot <- x$att.boot
-        res_boot <- res_boot[, which(apply(!is.na(res_boot), 2, all))]
+        ## drop = FALSE keeps res_boot a matrix even when only one
+        ## bootstrap column survives the all-non-NA filter (can occur
+        ## when small nboots interacts with NA-filled iterations from
+        ## parallel-worker errors).
+        res_boot <- res_boot[, which(apply(!is.na(res_boot), 2, all)),
+                             drop = FALSE]
         nboots <- ncol(res_boot)
         if (length(pre.pos) > 1) {
             res_boot <- res_boot[pre.pos, ]

--- a/R/plot.R
+++ b/R/plot.R
@@ -989,15 +989,10 @@ plot.fect <- function(
   ## c("placebo", "carryover", "carryover.rm"). The character form selects
   ## which test types receive the colored-glyph (and optional rectangle)
   ## treatment; other test periods render as plain circles.
-  ## carryover.rm has no dedicated slot on the fit object; recover the
-  ## value the user passed via fit$call.
-  has_rm_cells <- tryCatch({
-    arg <- as.list(x$call)$carryover.rm
-    if (is.null(arg)) FALSE else {
-      val <- suppressWarnings(as.integer(eval(arg)))
-      length(val) == 1L && !is.na(val) && val > 0
-    }
-  }, error = function(e) FALSE)
+  has_rm_cells <- {
+    K <- x$carryover.rm
+    is.numeric(K) && length(K) == 1L && !is.na(K) && K > 0
+  }
 
   highlight.types <- character(0)
   if (is.null(highlight)) {
@@ -3220,18 +3215,17 @@ plot.fect <- function(
       #
       # --- CARRYOVER TEST OR EXITING TREATMENT ---
       #
-      ## Detect carryover.rm value (number of post-treatment periods treated
-      ## as carryover) from the fit's stored call. With carryover.rm = K,
-      ## those K cells get the orange triangle "removed" glyph and the
-      ## carryover-test window is shifted by K periods. Default 0 (none).
-      carryover_rm_K <- 0L
-      tryCatch({
-        arg <- as.list(x$call)$carryover.rm
-        if (!is.null(arg)) {
-          val <- suppressWarnings(as.integer(eval(arg)))
-          if (length(val) == 1L && !is.na(val) && val > 0) carryover_rm_K <- val
+      ## With carryover.rm = K, those K cells get the orange triangle
+      ## "removed" glyph and the carryover-test window is shifted by K
+      ## periods. Default 0 (none). Read from the fit's stored slot.
+      carryover_rm_K <- {
+        K <- x$carryover.rm
+        if (is.numeric(K) && length(K) == 1L && !is.na(K) && K > 0) {
+          as.integer(K)
+        } else {
+          0L
         }
-      }, error = function(e) NULL)
+      }
 
       if (is.null(x$est.carryover) || carryover_rm_K == 0L) {
         placebo_seq <- c()

--- a/tests/testthat/test-carryover-rm-slot.R
+++ b/tests/testthat/test-carryover-rm-slot.R
@@ -1,0 +1,86 @@
+## ---------------------------------------------------------------
+## Tests for the explicit carryover.rm slot on the fit object.
+##
+## Pre-fix (v2.3.2 and earlier), plot.R recovered carryover.rm from
+## `as.list(x$call)$carryover.rm` and `eval(arg, envir = parent.frame())`.
+## That call-parsing path silently gave the wrong answer when the fit
+## was constructed via do.call(), wrappers that rewrote the call, or
+## when x$call was missing/altered. Storing carryover.rm directly on
+## the fit object makes the plot logic robust to all those paths.
+## ---------------------------------------------------------------
+
+suppressWarnings(data("simdata", package = "fect"))
+
+## -- C.1  Slot exists and matches the value passed at fit time --
+
+test_that("C.1: fit$carryover.rm is populated with the value passed to fect()", {
+
+  skip_on_cran()
+
+  set.seed(42)
+  fit <- suppressWarnings(suppressMessages(
+    fect::fect(
+      Y ~ D, data = simdata, index = c("id", "time"),
+      method = "ife", r = 1, CV = FALSE,
+      force = "two-way",
+      se = FALSE,
+      carryover.rm = 2
+    )
+  ))
+
+  expect_true("carryover.rm" %in% names(fit))
+  expect_equal(fit$carryover.rm, 2)
+})
+
+
+## -- C.2  Slot is NULL when the user does not pass carryover.rm --
+
+test_that("C.2: fit$carryover.rm is NULL when carryover.rm is not used", {
+
+  skip_on_cran()
+
+  set.seed(42)
+  fit <- suppressWarnings(suppressMessages(
+    fect::fect(
+      Y ~ D, data = simdata, index = c("id", "time"),
+      method = "ife", r = 1, CV = FALSE,
+      force = "two-way",
+      se = FALSE
+    )
+  ))
+
+  expect_null(fit$carryover.rm)
+})
+
+
+## -- C.3  Plot logic uses the slot, not x$call. Wipe x$call after
+## fitting and confirm that plot(fit) still recovers carryover_rm_K.
+## This is the regression test for the call-parsing fragility: the
+## old code would have read 0 from a call-less fit and rendered the
+## carryover plot with a missing K-shift; the new code reads from
+## x$carryover.rm and is unaffected.
+
+test_that("C.3: plot logic recovers carryover.rm even when x$call is wiped", {
+
+  skip_on_cran()
+
+  set.seed(42)
+  fit <- suppressWarnings(suppressMessages(
+    fect::fect(
+      Y ~ D, data = simdata, index = c("id", "time"),
+      method = "ife", r = 1, CV = FALSE,
+      force = "two-way",
+      se = FALSE,
+      carryover.rm = 2
+    )
+  ))
+
+  ## Wipe x$call to defeat the legacy call-parsing path.
+  fit$call <- NULL
+
+  ## The slot should still report K = 2, and plot.fect should not
+  ## throw. (We do not inspect the rendered plot's pixel content;
+  ## a successful build is the contract guard.)
+  expect_equal(fit$carryover.rm, 2)
+  expect_no_error(suppressWarnings(suppressMessages(plot(fit, type = "exit"))))
+})

--- a/tests/testthat/test-cv-parallel.R
+++ b/tests/testthat/test-cv-parallel.R
@@ -943,6 +943,49 @@ test_that("E.6: bootstrap + CV interaction (se=TRUE, nboots=5, parallel=TRUE) ru
   })
 })
 
+## -- E.7  Boot under stale future plan: simulate the CV→boot plan-leak
+##         that produced the E.6 PSOCK race. Set up a cluster plan,
+##         stop its workers behind future's back, then run boot. The
+##         cluster-init retry loop in run_dopar_retry should recover.
+test_that("E.7: bootstrap survives a stale future::plan() with dead workers", {
+
+  skip_on_cran()
+
+  ## Save / restore plan around the test.
+  old_plan <- future::plan()
+  on.exit(suppressWarnings(future::plan(old_plan)), add = TRUE)
+
+  ## Install a fresh PSOCK cluster, then forcibly kill its workers
+  ## while the plan still points at it. Mirrors the post-CV state the
+  ## bootstrap path inherits when CV's on.exit restores a plan whose
+  ## underlying cluster was stopped.
+  cl <- parallelly::makeClusterPSOCK(
+    workers      = 2L,
+    rscript_libs = .libPaths(),
+    autoStop     = TRUE
+  )
+  suppressWarnings(future::plan(future::cluster, workers = cl))
+  try(parallel::stopCluster(cl), silent = TRUE)
+
+  expect_no_error({
+    set.seed(42)
+    suppressWarnings(suppressMessages(
+      fect::fect(
+        Y ~ D,
+        data      = simdata,
+        index     = c("id", "time"),
+        method    = "ife",
+        r         = 0:1,
+        CV        = FALSE,
+        force     = "two-way",
+        se        = TRUE,
+        nboots    = 5,
+        parallel  = TRUE
+      )
+    ))
+  })
+})
+
 ## =================================================================
 ## Section G: Regression guard — nevertreated parallel paths
 ## =================================================================

--- a/vignettes/02-fect.Rmd
+++ b/vignettes/02-fect.Rmd
@@ -433,6 +433,58 @@ plot(out.w, main = "Estimated Weighted ATT")
 
 For finer control --- separating the weight that enters the outcome-model fit (`W.est`) from the weight that enters the aggregation (`W.agg`) --- and for important caveats when the weight is an inverse-probability weight, see [Chapter @sec-ife-mc] §Weights.
 
+### Post-hoc estimands from imputed potential outcomes
+
+The fit object exposes the full imputed counterfactual surface, so users can derive estimands beyond the default level-scale ATT --- for example the **average proportional treatment effect on the treated** (APTT) of @chen2024logs,
+
+$$
+\text{APTT}_t \;=\; \frac{\mathbb{E}\!\left[\,Y_{it} - \widehat{Y}_{it}(0) \mid D_{it}=1, t\,\right]}{\mathbb{E}\!\left[\,\widehat{Y}_{it}(0) \mid D_{it}=1, t\,\right]}.
+$$
+
+What's on the fit object: `Y.dat` and `D.dat` are the panel; `eff` is $Y_{it} - \widehat{Y}_{it}(0)$ at every cell, so $\widehat{Y}_{it}(0) = \texttt{Y.dat} - \texttt{eff}$; `T.on` is event time at each cell; `time` is the event-time grid. With `se = TRUE`, `att.boot` is a `length(time) × nboots` matrix of bootstrap level-ATT replicates by event time.
+
+A worked APTT example using `out.fect` (fit above with `nboots = 1000`):
+
+```{r aptt_example, eval = TRUE, message = FALSE}
+suppressPackageStartupMessages(library(dplyr))
+
+Don <- out.fect$D.dat == 1
+Y0  <- out.fect$Y.dat - out.fect$eff   # imputed Y(0) at every cell
+Ton <- out.fect$T.on                   # event time at every cell
+
+# Point APTT per event time (treated cells only)
+aptt_pt <- data.frame(
+  evt   = Ton[Don],
+  Y_obs = out.fect$Y.dat[Don],
+  Y0    = Y0[Don]
+) |>
+  group_by(evt) |>
+  summarise(att     = mean(Y_obs - Y0),
+            y0_mean = mean(Y0),
+            APTT    = att / y0_mean,
+            n_cells = dplyr::n(),
+            .groups = "drop")
+
+# Bootstrap CIs from att.boot, holding the denominator fixed at its
+# point estimate (conservative when imputation variance is small
+# relative to ATT sampling variance, which is typical for IFE).
+ti_grid     <- out.fect$time
+denom_byevt <- setNames(aptt_pt$y0_mean, aptt_pt$evt)
+denom_vec   <- denom_byevt[as.character(ti_grid)]
+APTT_boot   <- sweep(out.fect$att.boot, 1, denom_vec, "/")
+
+aptt_ci <- data.frame(
+  event.time = ti_grid,
+  APTT       = out.fect$att / denom_vec,
+  ci.lo      = apply(APTT_boot, 1, quantile, 0.025, na.rm = TRUE),
+  ci.hi      = apply(APTT_boot, 1, quantile, 0.975, na.rm = TRUE),
+  se         = apply(APTT_boot, 1, sd,             na.rm = TRUE)
+)
+head(na.omit(aptt_ci), 10)   # first 10 event times where APTT is computable
+```
+
+The same template --- read $(Y_{it}, \widehat{Y}_{it}(0))$ off the fit and aggregate by event time --- generalizes to log-scale ATTs (`log(Y_obs) - log(Y0)`), level-scale ATTs (the default), and any other functional of treated-cell outcomes. Native wrappers for these post-hoc estimands are planned for a future release.
+
 ## Additional notes
 
 1.  By default, the program will drop the units that have no larger than 5 observations under control, which is the reason why sometimes there are less available units in the placebo test or carryover test than in the original estimation. We can specify a preferred criterion in the option `min.T0` (default to 5). As a rule of thumb for the IFE estimator, the minimum number of observations under control for a unit should be larger than the specified number of factor `r`.

--- a/vignettes/bb-updates.Rmd
+++ b/vignettes/bb-updates.Rmd
@@ -1,5 +1,17 @@
 # Changelog {#sec-changelog .unnumbered}
 
+## v2.3.3
+
+(2026-04-28)
+
+**Bug fixes.**
+
+* `diagtest()` no longer crashes with "incorrect number of dimensions" when only one bootstrap column survives the all-non-NA filter (`drop = FALSE` at both filter sites in `R/diagtest.R`).
+* Bootstrap PSOCK cluster init now uses the shared `rscript_libs = .libPaths()` helper, wrapped in a 3-attempt retry-with-backoff. Eliminates the intermittent PSOCK race that surfaced in mixed CV+boot test runs; falls back to sequential bootstrap if `doParallel` also fails.
+* `carryover.rm` is now stored on the fit object. `plot.fect()` reads it from the slot rather than re-parsing `x$call`; correct under `do.call()`, programmatic wrappers, and any call-rewriting code path.
+
+**Documentation.** Chapter 2 §Other estimands gains a worked example for post-hoc estimands derived from the imputed potential-outcome surface, showing APTT [@chen2024logs] with bootstrap CIs from the existing fit slots.
+
 ## v2.3.2
 
 (2026-04-28)

--- a/vignettes/references.bib
+++ b/vignettes/references.bib
@@ -255,4 +255,15 @@ year = {2020}
   publisher={Wiley Online Library}
 }
 
+@article{chen2024logs,
+  title={Logs with Zeros? Some Problems and Solutions},
+  author={Chen, Jiafeng and Roth, Jonathan},
+  journal={The Quarterly Journal of Economics},
+  volume={139},
+  number={2},
+  pages={891--936},
+  year={2024},
+  doi={10.1093/qje/qjad054}
+}
+
 


### PR DESCRIPTION
## Summary

- **PSOCK race in CV → bootstrap chain.** When `parallel = TRUE` followed `CV = TRUE` in the same `fect()` call, the bootstrap path occasionally inherited a stale `future::plan()` whose underlying cluster had been torn down. The next `clusterCall(.libPaths)` could kill a worker mid-handshake, and `foreach(.errorhandling = "pass")` returned an error object in place of a fit. Downstream `apply()` / `array(..., dim=...)` then crashed with `"incorrect number of dimensions"`. Fix: bootstrap PSOCK cluster construction now uses the shared helper `.fect_make_future_cluster()` (which bakes `.libPaths()` into worker startup via `rscript_libs`), wrapped in a 3-attempt retry-with-backoff that shrinks worker count between attempts. If `doParallel` cluster init also fails after retries, the bootstrap degrades to sequential rather than crashing.

- **`diagtest()` matrix-shape edge case.** The all-non-NA column filter on `pre.att.boot` and `att.boot` could collapse the matrix to a vector when only one bootstrap column survived (rare but reachable when small `nboots` interacts with NA-filled iterations from worker errors). Downstream `res_boot[pre.pos, ]` then threw `"incorrect number of dimensions"`. Fix: pass `drop = FALSE` at both filter sites in `R/diagtest.R`.

- **`carryover.rm` is now stored explicitly on the fit object.** Pre-fix, `plot.fect()` recovered `carryover.rm` from `as.list(x$call)$carryover.rm` and `eval(arg, envir = parent.frame())`. That call-parsing path silently gave the wrong K under `do.call()`, programmatic wrappers, or any call-rewriting code path. The fit object now stores `carryover.rm` directly via `R/default.R`, and `R/plot.R` reads it from the slot. Behaviorally a no-op for fits built via named-argument `fect(...)`; correct under any other construction.

- **Quarto book chapter 2 §Other estimands** gains a new subsection on post-hoc estimands derived from the imputed potential-outcome surface, with a worked APTT (Chen & Roth 2024) example using the existing fit slots and bootstrap distribution. Closes the documentation side of issue #126 (ajunquera).

## Test plan

- [x] `R CMD check --as-cran` clean (0 ERROR / 0 WARN / 1 NOTE — HonestDiDFEct non-CRAN suggestion, expected)
- [x] `devtools::test()` 0 FAIL / 0 WARN
- [x] New `tests/testthat/test-carryover-rm-slot.R` (5 expectations): all pass
- [x] New `E.7` in `tests/testthat/test-cv-parallel.R` (stale-plan PSOCK race regression guard): passes
- [x] `test-cv-parallel.R` passes 74/74 in three independent fresh-session runs (E.6 race no longer flakes)
- [x] Quarto book renders end-to-end; new ch2 APTT example produces valid output (event time 1: APTT = 0.060 [0.016, 0.100], …)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
