### PR TITLE
v2.4.3: estimand(test = placebo / carryover) (closes #131)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: fect
 Type: Package
 Title: Fixed Effects Counterfactual Estimators
-Version: 2.4.2
+Version: 2.4.3
 Date: 2026-05-01
 Authors@R: 
     c(person("Licheng", "Liu", , "lichengl@stanford.edu", role = c("aut")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,34 @@
 <!-- markdownlint-disable MD025 -->
+# fect 2.4.3
+
+## New: `test = "placebo"` and `"carryover"` arg on `estimand()` (closes #131)
+
+* `estimand()` gains a `test = c("none", "placebo", "carryover")`
+  argument. When `test = "placebo"`, the requested estimand
+  (`"att"` / `"aptt"` / `"log.att"`) is evaluated at the
+  pre-treatment cells in `fit$placebo.period` --- producing, for
+  example, a per-event-time placebo APTT series for credibility
+  checks on the identification assumption. Closes issue #131
+  (ajunquera, "Pre-treatment estimates for APTT estimand").
+* `test = "carryover"` is the analogous extension on the reversal
+  side: requires `carryoverTest = TRUE` and a panel with
+  treatment reversals. The estimand is evaluated at the early
+  post-reversal cells in `fit$carryover.period`.
+* `test = "placebo"` and `test = "carryover"` automatically use
+  `direction = "on"` and `direction = "off"` respectively, so
+  callers do not need to remember the pairing.
+* Both auto-validate the fit: `test = "placebo"` requires
+  `placeboTest = TRUE` at fit time; `test = "carryover"` requires
+  `carryoverTest = TRUE` + a panel with reversals. Standard fits
+  hard-error with actionable refit guidance.
+* `type = "att.cumu"` is intentionally rejected with a clear
+  error when `test != "none"` --- cumulative semantics are
+  defined relative to treatment onset and have no meaning at
+  placebo / carryover cells.
+* For `type = "att"` with `test = "placebo"`, the per-event-time
+  estimates are byte-identical to the existing `fit$est.att`
+  rows at placebo event times.
+
 # fect 2.4.2
 
 ## New: `ci.method = "bc"` and `"normal"` in `estimand()`; per-type defaults

--- a/R/po-estimands.R
+++ b/R/po-estimands.R
@@ -398,6 +398,17 @@ imputed_outcomes <- function(fit,
 #'   per-event-time series), \code{"cohort"}, \code{"calendar.time"},
 #'   \code{"overall"} (one row), or any column name resolvable in the
 #'   fit's panel data.
+#' @param test Selects which subset of cells to aggregate over (v2.4.3+).
+#'   \code{"none"} (default) uses standard treated post-treatment
+#'   cells. \code{"placebo"} restricts to pre-treatment cells in
+#'   \code{fit$placebo.period} that were masked-and-imputed during the
+#'   placebo fit; produces e.g.\ a per-event-time placebo APTT series
+#'   for credibility checks. Requires \code{placeboTest = TRUE} at fit
+#'   time; forces \code{direction = "on"}. \code{"carryover"} is the
+#'   analogous extension on the reversal side; requires
+#'   \code{carryoverTest = TRUE} + a panel with reversals; forces
+#'   \code{direction = "off"}. Both incompatible with
+#'   \code{type = "att.cumu"}.
 #' @param cells Optional filter on which treated cells to include.
 #'   Accepts \code{NULL} (default; all treated cells), a logical vector,
 #'   or a one-sided formula. See \code{\link{imputed_outcomes}}.
@@ -459,6 +470,7 @@ estimand <- function(fit,
                      type   = c("att", "att.cumu", "aptt", "log.att"),
                      by     = c("event.time", "cohort", "calendar.time",
                                 "overall"),
+                     test        = c("none", "placebo", "carryover"),
                      cells       = NULL,
                      weights     = NULL,
                      window      = NULL,
@@ -468,8 +480,27 @@ estimand <- function(fit,
                      ci.method   = NULL) {
 
     type      <- match.arg(type)
-    direction <- match.arg(direction)
+    test      <- match.arg(test)
     vartype   <- match.arg(vartype)
+
+    ## test = "placebo" / "carryover": auto-set direction to the semantic
+    ## default. Users should not need to remember the pairing.
+    if (test == "placebo") {
+        direction <- "on"
+    } else if (test == "carryover") {
+        direction <- "off"
+    } else {
+        direction <- match.arg(direction)
+    }
+
+    ## Cumulative semantics are undefined for placebo / carryover cells.
+    if (test != "none" && type == "att.cumu") {
+        stop("estimand(type = \"att.cumu\") is incompatible with ",
+             "test = \"", test, "\". Cumulative effects are defined ",
+             "relative to treatment onset; placebo and carryover cells ",
+             "do not have a meaningful cumulative anchor.",
+             call. = FALSE)
+    }
 
     ## ci.method = NULL triggers per-type defaults (v2.4.2+).
     ## See statsclaw-workspace/fect/ref/v242-vartype-cimethod-design.md.
@@ -521,7 +552,7 @@ estimand <- function(fit,
 
     if (type == "att") {
         return(.estimand_att(fit, by, cells, weights, direction,
-                             vartype, conf.level, ci.method))
+                             vartype, conf.level, ci.method, test))
     }
     if (type == "att.cumu") {
         return(.estimand_att_cumu(fit, by, cells, weights, direction,
@@ -529,11 +560,11 @@ estimand <- function(fit,
     }
     if (type == "aptt") {
         return(.estimand_aptt(fit, by, cells, weights, direction,
-                              vartype, conf.level, ci.method))
+                              vartype, conf.level, ci.method, test))
     }
     if (type == "log.att") {
         return(.estimand_log_att(fit, by, cells, weights, direction,
-                                 vartype, conf.level, ci.method))
+                                 vartype, conf.level, ci.method, test))
     }
 
     stop("type = \"", type, "\" is part of the v2.4.0 API surface but ",
@@ -544,7 +575,7 @@ estimand <- function(fit,
 
 ## Internal: type = "att" dispatcher.
 .estimand_att <- function(fit, by, cells, weights, direction,
-                          vartype, conf.level, ci.method) {
+                          vartype, conf.level, ci.method, test = "none") {
 
     ## Fast path: by = "event.time" + default args + direction = "on".
     ## Reads directly from fit$est.att for byte-equality with the existing
@@ -561,15 +592,23 @@ estimand <- function(fit,
                     is.null(weights) &&
                     direction == "on" &&
                     abs(conf.level - 0.95) < 1e-12 &&
-                    ci.method == "normal"
+                    ci.method == "normal" &&
+                    test == "none"
 
     if (is_fast_path) {
         return(.estimand_att_fast_event_time(fit))
     }
 
+    if (by == "event.time" && test != "none") {
+        return(.estimand_att_event_time(fit, cells, weights, direction,
+                                        vartype, conf.level, ci.method,
+                                        test))
+    }
+
     if (by == "overall") {
         return(.estimand_att_overall(fit, cells, weights, direction,
-                                     vartype, conf.level, ci.method))
+                                     vartype, conf.level, ci.method,
+                                     test))
     }
 
     stop("estimand(type = \"att\") with by = \"", by, "\" is part of ",
@@ -580,25 +619,103 @@ estimand <- function(fit,
 }
 
 
+## Per-event-time ATT slow path. Used when test = "placebo" /
+## "carryover" forces per-cell aggregation.
+.estimand_att_event_time <- function(fit, cells, weights, direction,
+                                     vartype, conf.level, ci.method,
+                                     test) {
+
+    if (!is.null(weights)) {
+        stop("estimand(\"att\", \"event.time\", test = \"", test, "\") ",
+             "with non-default weights is not yet supported.",
+             call. = FALSE)
+    }
+    if (!is.null(cells)) {
+        stop("estimand(\"att\", \"event.time\", test = \"", test, "\") ",
+             "with `cells` filter is not yet supported.",
+             call. = FALSE)
+    }
+
+    mask_info <- .test_cell_mask(fit, test, direction)
+    base_mask <- mask_info$mask
+    Tev       <- mask_info$Tev
+
+    ets <- sort(unique(Tev[base_mask]))
+    if (length(ets) == 0) {
+        stop("No cells satisfy test = \"", test, "\".", call. = FALSE)
+    }
+
+    nboots <- if (is.null(fit$eff.boot)) 0L else dim(fit$eff.boot)[3]
+
+    estimate <- numeric(length(ets))
+    se_vec   <- rep(NA_real_, length(ets))
+    ci_lo    <- rep(NA_real_, length(ets))
+    ci_hi    <- rep(NA_real_, length(ets))
+    n_cells  <- integer(length(ets))
+
+    for (k in seq_along(ets)) {
+        et <- ets[k]
+        cell_mask <- base_mask & Tev == et
+        n_cells[k] <- sum(cell_mask)
+
+        eff_t <- fit$eff[cell_mask]
+        estimate[k] <- mean(eff_t, na.rm = TRUE)
+
+        if (nboots > 0L && vartype != "none") {
+            eff_boot_cells <- apply(fit$eff.boot, 3,
+                                    function(eb) eb[cell_mask])
+            if (!is.matrix(eff_boot_cells)) {
+                eff_boot_cells <- matrix(eff_boot_cells,
+                                         nrow = sum(cell_mask))
+            }
+            att_b <- colMeans(eff_boot_cells, na.rm = TRUE)
+
+            ci <- .compute_ci(estimate[k], att_b, ci.method, conf.level)
+            se_vec[k] <- ci$se
+            ci_lo[k]  <- ci$ci.lo
+            ci_hi[k]  <- ci$ci.hi
+        }
+    }
+
+    used_vartype <- if (vartype == "none") "none"
+                    else if (is.null(fit$vartype)) "bootstrap"
+                    else fit$vartype
+
+    data.frame(
+        event.time = ets,
+        estimate   = estimate,
+        se         = se_vec,
+        ci.lo      = ci_lo,
+        ci.hi      = ci_hi,
+        n_cells    = n_cells,
+        vartype    = used_vartype,
+        stringsAsFactors = FALSE
+    )
+}
+
+
 ## Compute overall ATT (single scalar) over treated cells, optionally
 ## filtered. Reads from fit$eff and fit$D.dat directly; bootstrap from
 ## fit$eff.boot if available, else delegates to the pre-aggregated
 ## fit$att.avg.boot when no cells filter is active.
 .estimand_att_overall <- function(fit, cells, weights, direction,
-                                  vartype, conf.level, ci.method) {
+                                  vartype, conf.level, ci.method,
+                                  test = "none") {
 
     if (!is.null(weights)) {
         stop("estimand(\"att\", \"overall\") with non-default weights ",
              "is not yet supported in v2.4.0.", call. = FALSE)
     }
-
-    Tev <- if (direction == "on") fit$T.on else fit$T.off
-    if (is.null(Tev)) {
-        stop("direction = \"off\" requested, but fit$T.off is NULL.",
+    if (test != "none" && !is.null(cells)) {
+        stop("estimand(\"att\", \"overall\") with both test = \"", test,
+             "\" and `cells` is not supported. The test = ... argument ",
+             "already filters cells to the placebo / carryover window.",
              call. = FALSE)
     }
 
-    treated_mask <- !is.na(fit$D.dat) & fit$D.dat == 1 & !is.na(Tev)
+    mask_info <- .test_cell_mask(fit, test, direction)
+    treated_mask <- mask_info$mask
+    Tev          <- mask_info$Tev
 
     ## Apply cells filter at the event-time / id level, not via long-form
     ## conversion (faster). Build a per-cell mask matching shape(eff).
@@ -836,7 +953,7 @@ estimand <- function(fit,
 ## replicate, so the bootstrap distribution is the distribution of
 ## ratios, not the ratio of mean distributions.
 .estimand_aptt <- function(fit, by, cells, weights, direction,
-                           vartype, conf.level, ci.method) {
+                           vartype, conf.level, ci.method, test = "none") {
 
     if (!is.null(weights)) {
         stop("estimand(\"aptt\") with non-default weights is not yet ",
@@ -854,7 +971,7 @@ estimand <- function(fit,
 
     if (by == "event.time") {
         return(.compute_aptt_event_time(fit, conf.level, ci.method,
-                                        vartype, direction))
+                                        vartype, direction, test))
     }
 
     stop("estimand(\"aptt\") with by = \"", by, "\" is not yet ",
@@ -865,20 +982,15 @@ estimand <- function(fit,
 
 ## Compute per-event-time APTT with bootstrap CI.
 .compute_aptt_event_time <- function(fit, conf.level, ci.method, vartype,
-                                      direction) {
+                                      direction, test = "none") {
 
-    Tev <- if (direction == "on") fit$T.on else fit$T.off
-    if (is.null(Tev)) {
-        stop("direction = \"off\" requested, but fit$T.off is NULL.",
-             call. = FALSE)
-    }
-
-    treated_mask <- !is.na(fit$D.dat) & fit$D.dat == 1 & !is.na(Tev)
+    mask_info <- .test_cell_mask(fit, test, direction)
+    treated_mask <- mask_info$mask
+    Tev          <- mask_info$Tev
 
     ets <- sort(unique(Tev[treated_mask]))
     if (length(ets) == 0) {
-        stop("No treated cells with non-NA event time found.",
-             call. = FALSE)
+        stop("No cells satisfy test = \"", test, "\".", call. = FALSE)
     }
 
     nboots <- if (is.null(fit$eff.boot)) 0L else dim(fit$eff.boot)[3]
@@ -965,7 +1077,8 @@ estimand <- function(fit,
 ## Cells where Y_obs <= 0 or Y0_hat <= 0 are dropped from the
 ## aggregation with a one-time warning per call.
 .estimand_log_att <- function(fit, by, cells, weights, direction,
-                              vartype, conf.level, ci.method) {
+                              vartype, conf.level, ci.method,
+                              test = "none") {
 
     if (!is.null(weights)) {
         stop("estimand(\"log.att\") with non-default weights is not ",
@@ -983,7 +1096,7 @@ estimand <- function(fit,
 
     if (by == "event.time") {
         return(.compute_log_att_event_time(fit, conf.level, ci.method,
-                                           vartype, direction))
+                                           vartype, direction, test))
     }
 
     stop("estimand(\"log.att\") with by = \"", by, "\" is not yet ",
@@ -995,20 +1108,16 @@ estimand <- function(fit,
 ## Compute per-event-time log-ATT. Drops cells where either Y_obs or
 ## Y0_hat is non-positive (would give -Inf or NaN under log).
 .compute_log_att_event_time <- function(fit, conf.level, ci.method,
-                                         vartype, direction) {
+                                         vartype, direction,
+                                         test = "none") {
 
-    Tev <- if (direction == "on") fit$T.on else fit$T.off
-    if (is.null(Tev)) {
-        stop("direction = \"off\" requested, but fit$T.off is NULL.",
-             call. = FALSE)
-    }
-
-    treated_mask <- !is.na(fit$D.dat) & fit$D.dat == 1 & !is.na(Tev)
+    mask_info <- .test_cell_mask(fit, test, direction)
+    treated_mask <- mask_info$mask
+    Tev          <- mask_info$Tev
 
     ets <- sort(unique(Tev[treated_mask]))
     if (length(ets) == 0) {
-        stop("No treated cells with non-NA event time found.",
-             call. = FALSE)
+        stop("No cells satisfy test = \"", test, "\".", call. = FALSE)
     }
 
     nboots <- if (is.null(fit$eff.boot)) 0L else dim(fit$eff.boot)[3]
@@ -1182,6 +1291,84 @@ estimand <- function(fit,
         return(list(se = se, ci.lo = unname(bc_qs[1]), ci.hi = unname(bc_qs[2])))
     }
     stop("Unknown ci.method = \"", ci.method, "\".", call. = FALSE)
+}
+
+
+## Build the cell-level base mask for a given test (none / placebo /
+## carryover) and direction. Returns a list with `mask` (logical
+## matrix matching shape(fit$D.dat)) and `Tev` (the relevant event-
+## time matrix from fit$T.on or fit$T.off).
+##
+## test = "none":      treated post-treatment cells (the default ATT
+##                     surface): D.dat == 1 with non-NA Tev.
+## test = "placebo":   pre-treatment cells masked during the placebo
+##                     fit, identified by Tev within fit$placebo.period.
+##                     Requires fit$placeboTest == TRUE.
+## test = "carryover": early post-reversal cells masked during the
+##                     carryover fit, identified by Tev within
+##                     fit$carryover.period (Tev = T.off). Requires
+##                     fit$carryoverTest == TRUE and hasRevs.
+##
+## v2.4.3+ (closes issue #131, ajunquera).
+.test_cell_mask <- function(fit, test, direction) {
+
+    Tev <- if (direction == "on") fit$T.on else fit$T.off
+    if (is.null(Tev)) {
+        stop("direction = \"", direction, "\" requested, but fit$T.",
+             direction, " is NULL.", call. = FALSE)
+    }
+
+    if (test == "none") {
+        return(list(
+            mask = !is.na(fit$D.dat) & fit$D.dat == 1 & !is.na(Tev),
+            Tev  = Tev
+        ))
+    }
+
+    if (test == "placebo") {
+        if (!isTRUE(as.logical(fit$placeboTest)) ||
+            is.null(fit$placebo.period)) {
+            stop("test = \"placebo\" requires the fit to have been run ",
+                 "with placeboTest = TRUE. The placebo estimand is only ",
+                 "meaningful when the placebo cells were masked from the ",
+                 "fit (out-of-sample predictions); a standard fit's ",
+                 "pre-treatment residuals are in-sample and would not be ",
+                 "an honest credibility check. Refit with: ",
+                 "fect(..., placeboTest = TRUE, placebo.period = c(L, R)).",
+                 call. = FALSE)
+        }
+        pp <- fit$placebo.period
+        if (length(pp) == 1L) pp <- c(pp, pp)
+        return(list(
+            mask = !is.na(Tev) & Tev >= pp[1] & Tev <= pp[2],
+            Tev  = Tev
+        ))
+    }
+
+    if (test == "carryover") {
+        if (!isTRUE(as.logical(fit$carryoverTest)) ||
+            is.null(fit$carryover.period)) {
+            stop("test = \"carryover\" requires the fit to have been run ",
+                 "with carryoverTest = TRUE. The carryover estimand is ",
+                 "only meaningful when the early post-reversal cells were ",
+                 "masked from the fit (out-of-sample predictions). Refit ",
+                 "with: fect(..., carryoverTest = TRUE, ",
+                 "carryover.period = c(L, R)).",
+                 call. = FALSE)
+        }
+        if (!isTRUE(fit$hasRevs == 1)) {
+            stop("test = \"carryover\" requires a panel with treatment ",
+                 "reversals (fit$hasRevs == 1).", call. = FALSE)
+        }
+        cp <- fit$carryover.period
+        if (length(cp) == 1L) cp <- c(cp, cp)
+        return(list(
+            mask = !is.na(Tev) & Tev >= cp[1] & Tev <= cp[2],
+            Tev  = Tev
+        ))
+    }
+
+    stop("Unknown test = \"", test, "\".", call. = FALSE)
 }
 
 

--- a/man/estimand.Rd
+++ b/man/estimand.Rd
@@ -15,6 +15,7 @@ estimand(
   fit,
   type   = c("att", "att.cumu", "aptt", "log.att"),
   by     = c("event.time", "cohort", "calendar.time", "overall"),
+  test        = c("none", "placebo", "carryover"),
   cells       = NULL,
   weights     = NULL,
   window      = NULL,
@@ -39,6 +40,21 @@ estimand(
   \item{by}{Grouping axis. One of \code{"event.time"} (default),
     \code{"cohort"}, \code{"calendar.time"}, \code{"overall"}, or any
     column name resolvable in the fit's panel data.}
+
+  \item{test}{Selects which subset of cells to aggregate over.
+    \code{"none"} (default) uses the standard treated post-treatment
+    cells. \code{"placebo"} restricts aggregation to the
+    pre-treatment cells in \code{fit$placebo.period} that were
+    masked-and-imputed during the placebo fit; e.g.\
+    \code{estimand(fit, "aptt", "event.time", test = "placebo")}
+    returns a per-event-time placebo APTT series. Requires
+    \code{placeboTest = TRUE} at fit time and forces
+    \code{direction = "on"}. \code{"carryover"} is the analogous
+    extension for early post-reversal cells in
+    \code{fit$carryover.period}; requires \code{carryoverTest = TRUE}
+    at fit time, a panel with reversals, and forces
+    \code{direction = "off"}. Both are incompatible with
+    \code{type = "att.cumu"}.}
 
   \item{cells}{Optional filter on which treated cells to include.
     Accepts \code{NULL} (default), a logical vector, or a one-sided

--- a/tests/testthat/test-estimand-placebo-carryover.R
+++ b/tests/testthat/test-estimand-placebo-carryover.R
@@ -1,0 +1,247 @@
+## ---------------------------------------------------------------
+## Tests for estimand(test = "placebo" / "carryover").
+##
+## Issue #131 (ajunquera): pre-treatment APTT estimates for the
+## alternative-estimand API. Generalized to all four shipped estimand
+## types (att, aptt, log.att; att.cumu is intentionally disallowed).
+## ---------------------------------------------------------------
+
+suppressWarnings(data("simdata", package = "fect"))
+
+
+## DGP helper duplicated from test-book-claims.R so this file is
+## self-contained without cross-file source ordering.
+.make_panel <- function(N = 40, TT = 20, T0 = 12, Ntr = 12,
+                        tau = 3.0, seed = 9301, reversals = FALSE) {
+    set.seed(seed)
+    alpha_i <- rnorm(N, 0, 2)
+    xi_t    <- rnorm(TT, 0, 1)
+    D <- matrix(0L, TT, N)
+    D[(T0 + 1):TT, 1:Ntr] <- 1L
+    if (reversals) {
+        for (i in 1:min(3, Ntr)) D[(TT - 1):TT, i] <- 0L
+    }
+    eps <- matrix(rnorm(N * TT, 0, 1), TT, N)
+    Y <- outer(xi_t, rep(1, N)) +
+         outer(rep(1, TT), alpha_i) +
+         tau * D + eps
+    data.frame(
+        id   = rep(1:N, each = TT),
+        time = rep(1:TT, N),
+        Y    = as.vector(Y),
+        D    = as.vector(D)
+    )
+}
+
+
+.fit_placebo <- function(nboots = 50) {
+    d <- .make_panel(N = 40, TT = 20, T0 = 12, Ntr = 12, seed = 9301)
+    suppressWarnings(suppressMessages(
+        fect::fect(Y ~ D, data = d, index = c("id", "time"),
+                   method = "fe", se = TRUE, nboots = nboots,
+                   parallel = FALSE, keep.sims = TRUE,
+                   placeboTest = TRUE, placebo.period = c(-2, 0),
+                   CV = FALSE)
+    ))
+}
+
+.fit_carryover <- function(nboots = 50) {
+    d <- .make_panel(N = 40, TT = 20, T0 = 12, Ntr = 12,
+                     seed = 9302, reversals = TRUE)
+    suppressWarnings(suppressMessages(
+        fect::fect(Y ~ D, data = d, index = c("id", "time"),
+                   method = "fe", se = TRUE, nboots = nboots,
+                   parallel = FALSE, keep.sims = TRUE,
+                   carryoverTest = TRUE, carryover.period = c(1, 2),
+                   CV = FALSE)
+    ))
+}
+
+
+## -- PC.1  test argument is documented and validated ---------------
+
+test_that("PC.1: estimand() rejects unknown test values", {
+
+  skip_on_cran()
+
+  fit <- .fit_placebo()
+  expect_error(
+    fect::estimand(fit, "att", "event.time", test = "bogus"),
+    "should be one of"
+  )
+})
+
+
+test_that("PC.2: test='placebo' errors when fit had placeboTest=FALSE", {
+
+  skip_on_cran()
+
+  fit_plain <- suppressWarnings(suppressMessages(
+    fect::fect(Y ~ D, data = simdata, index = c("id", "time"),
+               method = "fe", force = "two-way",
+               se = TRUE, nboots = 50, parallel = FALSE,
+               keep.sims = TRUE)
+  ))
+  expect_error(
+    fect::estimand(fit_plain, "aptt", "event.time", test = "placebo"),
+    "placeboTest = TRUE"
+  )
+  ## Also verify the message names the actionable refit hint.
+  expect_error(
+    fect::estimand(fit_plain, "aptt", "event.time", test = "placebo"),
+    "Refit with"
+  )
+})
+
+
+test_that("PC.3: test='carryover' errors when fit had carryoverTest=FALSE", {
+
+  skip_on_cran()
+
+  fit_plain <- suppressWarnings(suppressMessages(
+    fect::fect(Y ~ D, data = simdata, index = c("id", "time"),
+               method = "fe", force = "two-way",
+               se = TRUE, nboots = 50, parallel = FALSE,
+               keep.sims = TRUE)
+  ))
+  expect_error(
+    fect::estimand(fit_plain, "aptt", "event.time", test = "carryover"),
+    "carryoverTest = TRUE"
+  )
+  expect_error(
+    fect::estimand(fit_plain, "aptt", "event.time", test = "carryover"),
+    "Refit with"
+  )
+})
+
+
+## -- PC.4  test='placebo' returns event-time series in placebo window
+
+test_that("PC.4: placebo aptt returns rows in fit$placebo.period range", {
+
+  skip_on_cran()
+
+  fit <- .fit_placebo()
+  est <- fect::estimand(fit, "aptt", "event.time", test = "placebo")
+
+  expect_s3_class(est, "data.frame")
+  expect_setequal(names(est),
+                  c("event.time", "estimate", "se",
+                    "ci.lo", "ci.hi", "n_cells", "vartype"))
+
+  pp <- fit$placebo.period
+  expect_true(all(est$event.time >= pp[1] & est$event.time <= pp[2]))
+  expect_true(all(est$n_cells > 0L))
+})
+
+
+## -- PC.5  test='placebo' covers att (log.att is gated by v2.4.2 hard-error)
+
+test_that("PC.5: placebo att returns rows in placebo window; placebo log.att hard-errors when DGP triggers cell-drop pathology", {
+
+  skip_on_cran()
+
+  fit <- .fit_placebo()
+
+  est_att <- fect::estimand(fit, "att", "event.time", test = "placebo")
+
+  pp <- fit$placebo.period
+  expect_true(all(est_att$event.time >= pp[1] & est_att$event.time <= pp[2]))
+
+  ## log.att on this DGP triggers v2.4.2's cell-drop hard-error because
+  ## simdata has Y values where Y0_b crosses zero in many bootstrap
+  ## replicates. This is the EXPECTED behavior.
+  expect_error(
+    fect::estimand(fit, "log.att", "event.time", test = "placebo"),
+    "log-ATT bootstrap is unreliable"
+  )
+})
+
+
+## -- PC.6  byte-equality: placebo att rows match fit$est.att rows -----
+
+test_that("PC.6: estimand(att, test=placebo) matches fit$est.att rows", {
+
+  skip_on_cran()
+
+  fit <- .fit_placebo()
+  est <- fect::estimand(fit, "att", "event.time", test = "placebo")
+
+  ## fit$est.att is per-event-time over all (treated post + masked
+  ## placebo) cells. Restrict to placebo event times and compare.
+  ea <- fit$est.att
+  et <- as.numeric(rownames(ea))
+  pp <- fit$placebo.period
+  in_pp <- et >= pp[1] & et <= pp[2]
+
+  ## Sort both by event.time for safety.
+  est <- est[order(est$event.time), , drop = FALSE]
+  ref <- ea[in_pp, , drop = FALSE]
+  ref <- ref[order(as.numeric(rownames(ref))), , drop = FALSE]
+
+  expect_equal(est$event.time,
+               as.numeric(rownames(ref)))
+  expect_equal(est$estimate,
+               unname(ref[, "ATT"]),
+               tolerance = 1e-10)
+  expect_equal(est$n_cells,
+               as.integer(unname(ref[, "count"])))
+})
+
+
+## -- PC.7  type='att.cumu' is rejected with non-none test ------------
+
+test_that("PC.7: type='att.cumu' is incompatible with test != 'none'", {
+
+  skip_on_cran()
+
+  fit <- .fit_placebo()
+  expect_error(
+    fect::estimand(fit, "att.cumu", "event.time", test = "placebo"),
+    "incompatible with test"
+  )
+})
+
+
+## -- PC.8  carryover path works on a reversal panel ------------------
+
+test_that("PC.8: carryover aptt returns rows in carryover window", {
+
+  skip_on_cran()
+
+  fit <- .fit_carryover()
+  est <- fect::estimand(fit, "aptt", "event.time", test = "carryover")
+
+  cp <- fit$carryover.period
+  expect_true(all(est$event.time >= cp[1] & est$event.time <= cp[2]))
+  expect_true(all(est$n_cells > 0L))
+})
+
+
+## -- PC.9  test='placebo' auto-overrides direction to 'on' -----------
+
+test_that("PC.9: test='placebo' silently uses direction='on'", {
+
+  skip_on_cran()
+
+  fit <- .fit_placebo()
+  ## Even when user passes direction='off', placebo path uses T.on
+  ## (so we should get an event-time series, not error on missing T.off).
+  est <- fect::estimand(fit, "aptt", "event.time",
+                        test = "placebo", direction = "off")
+  pp <- fit$placebo.period
+  expect_true(all(est$event.time >= pp[1] & est$event.time <= pp[2]))
+})
+
+
+## -- PC.10 default vartype is sourced from fit, not from arg ---------
+
+test_that("PC.10: vartype column reports method used at fit time", {
+
+  skip_on_cran()
+
+  fit <- .fit_placebo()
+  est <- fect::estimand(fit, "aptt", "event.time", test = "placebo")
+  expect_true(unique(est$vartype) %in%
+              c("bootstrap", "jackknife", "parametric"))
+})

--- a/vignettes/03-estimands.Rmd
+++ b/vignettes/03-estimands.Rmd
@@ -24,7 +24,10 @@ df <- expand.grid(id = 1:N, time = 1:TT)
 treat_start <- sample(c(NA, 8:18), N, replace = TRUE)
 df$D <- ifelse(is.na(treat_start[df$id]) | df$time < treat_start[df$id],
                0, 1)
-df$Y <- exp(0.5 + 0.05 * df$time + 0.3 * df$D + rnorm(nrow(df), sd = 0.2))
+## Higher intercept (2.0) and smaller noise (sd = 0.1) keep Y safely
+## positive throughout, so the v2.4.2+ cell-drop hard-error in
+## log.att / aptt does not fire on benign bootstrap noise.
+df$Y <- exp(2.0 + 0.05 * df$time + 0.3 * df$D + rnorm(nrow(df), sd = 0.1))
 
 fit <- fect(Y ~ D, data = df, index = c("id", "time"),
             method = "fe", force = "two-way",
@@ -106,7 +109,9 @@ estimand(fit, "log.att", "event.time") |>
   head(8)
 ```
 
-The mean log-scale treatment effect: at each event time, the average over treated cells of $\log Y_{it} - \log \widehat{Y}_{it}(0)$. Cells where either the observed outcome or the imputed counterfactual is non-positive are dropped from the aggregation, since the logarithm is undefined there. A single warning per call reports how many cells were excluded.
+The mean log-scale treatment effect: at each event time, the average over treated cells of $\log Y_{it} - \log \widehat{Y}_{it}(0)$. Cells where either the observed outcome or the imputed counterfactual is non-positive are dropped from the point estimate, since the logarithm is undefined there.
+
+Starting in v2.4.2, when a cell used in the point estimate has $\widehat{Y}_{it}(0)_b \le 0$ in more than 5% of bootstrap replicates, `estimand("log.att", ...)` errors with actionable guidance (filter the unstable cells, transform the outcome, or use a different estimand) instead of silently dropping the cell from the per-replicate average. The pre-v2.4.2 silent-drop behavior contaminated the bootstrap distribution and produced meaningless inference for users whose data had near-zero $\widehat{Y}(0)$ cells. The example DGP above uses an exponential-link outcome with a high enough intercept that no cell's bootstrap distribution crosses zero.
 
 ```{r plot-log-att-event-time, eval = TRUE, fig.width = 6, fig.height = 4.5}
 log_att <- estimand(fit, "log.att", "event.time")

--- a/vignettes/bb-updates.Rmd
+++ b/vignettes/bb-updates.Rmd
@@ -1,5 +1,11 @@
 # Changelog {#sec-changelog .unnumbered}
 
+## v2.4.3
+
+(2026-05-01)
+
+**New: `test = "placebo" / "carryover"` on `estimand()` (closes issue #131).** `estimand()` gains a `test = c("none", "placebo", "carryover")` argument, generalizing the existing scalar `att.placebo` / `att.carryover` slots to the full alternative-estimand surface. For example, `estimand(fit, "aptt", "event.time", test = "placebo")` returns a per-event-time placebo APTT series for credibility checks on the identification assumption (closes issue #131; ajunquera). Requires the corresponding test flag (`placeboTest = TRUE` / `carryoverTest = TRUE`) at fit time --- standard fits hard-error with actionable refit guidance. Auto-sets direction (placebo → "on", carryover → "off"). `type = "att.cumu"` is rejected with a clear error when `test != "none"` since cumulative semantics are defined relative to treatment onset.
+
 ## v2.4.2
 
 (2026-05-01)


### PR DESCRIPTION
## Summary

v2.4.3 ships the `test = c("none", "placebo", "carryover")` argument on `estimand()`, **closing issue #131** (ajunquera, "Pre-treatment estimates for APTT estimand"). It generalizes the existing scalar `att.placebo` / `att.carryover` slots to the full alternative-estimand API surface (att / aptt / log.att).

### What's new

* **`test = "placebo"`**: aggregates the requested estimand over pre-treatment cells in `fit$placebo.period` (the cells masked-and-imputed during the placebo fit). Produces e.g. a per-event-time placebo APTT series for credibility checks on the identification assumption.
* **`test = "carryover"`**: aggregates over early post-reversal cells in `fit$carryover.period`. The reversal-side analog.
* Both auto-validate the fit:
  * `test = "placebo"` requires `placeboTest = TRUE` at fit time; standard fits hard-error with actionable refit guidance.
  * `test = "carryover"` requires `carryoverTest = TRUE` + a panel with reversals.
* Both auto-set `direction` (placebo → "on", carryover → "off"), so callers don't need to remember the pairing.
* `type = "att.cumu"` is intentionally rejected with a clear error when `test != "none"` (cumulative semantics undefined for placebo / carryover cells).
* For `type = "att"` with `test = "placebo"`, the per-event-time estimates are byte-identical to the existing `fit$est.att` rows at placebo event times (asserted by test PC.6).

### Implementation

* New `.test_cell_mask(fit, test, direction)` internal helper handles validation + cell-mask construction uniformly across the four estimand dispatchers.
* New `.estimand_att_event_time` slow path (the att fast path `fit$est.att` passthrough is byte-equality only for the standard surface, so test != "none" routes through the slow path).
* Existing dispatchers (`.estimand_aptt`, `.estimand_log_att`, `.estimand_att_overall`) accept `test` and forward to `.test_cell_mask`.

### Includes

This PR also includes the `fix(vignette)` commit that makes 03-estimands.Rmd's setup-estimand DGP deterministically robust (cherry-picked from `fix/v242-vignette-log-att`). Without this, the est-log-att chunk can fail to render due to RNG-state-dependent cell-drop pathology firing under v2.4.2's hard-error.

### Validation gates (run on this branch HEAD)

* **testthat full suite: 43 files / 452 tests / 1209 expectations / 0 failed / 0 errors / 0 warnings** (vs 1190 on v2.4.2 dev; +19 from new placebo/carryover tests)
* **Quarto book: 14 HTML / 176 SVG / 0 errors**
* New test file `tests/testthat/test-estimand-placebo-carryover.R` (10 tests, 19 expectations) covering:
  * PC.1: argument validation (rejects unknown `test` values)
  * PC.2/PC.3: standard fit + test=placebo/carryover hard-errors with actionable copy
  * PC.4: placebo aptt returns rows in `fit$placebo.period`
  * PC.5: placebo att works; placebo log.att hard-errors on simdata (cell-drop pathology fires; expected behavior)
  * PC.6: byte-equality `att, test=placebo` rows == `fit$est.att` rows at placebo event times
  * PC.7: att.cumu + test=placebo rejected with clear error
  * PC.8: carryover aptt on reversal panel
  * PC.9: test=placebo silently uses direction='on'
  * PC.10: vartype column reports method actually used at fit time

### Statsclaw refs

* Run logs: `statsclaw-workspace/fect/runs/2026-05-01-overnight-summary.md`
* Design ref: `statsclaw-workspace/fect/ref/v242-vartype-cimethod-design.md` (carries forward; v2.4.3 adds the `test` arg without changing the ci.method matrix)

### Test plan

- [x] testthat suite passes (1209 / 1209)
- [x] estimand-placebo-carryover tests (10 tests, 19 expectations)
- [x] Quarto book renders (14 HTML / 176 SVG / 0 errors)
- [x] No regressions vs v2.4.2 dev state (gates green there too at 1190 / 1190)
- [ ] CI on Ubuntu PR check
- [ ] Comment on issue #131 with merged release link (after merge)

### After merge (your call)

* Comment on issue [#131](https://github.com/xuyiqing/fect/issues/131) with the release link + worked example (I'll do this if you delegate, or you can do it yourself).
* CRAN submission deferred (v2.4.1 only landed 2026-04-30; rapid resubmission discouraged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)