### PR TITLE
v2.4.3: fix quiet_nonpara closure leak in parallel bootstrap

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: fect
 Type: Package
 Title: Fixed Effects Counterfactual Estimators
-Version: 2.4.2
-Date: 2026-05-04
+Version: 2.4.3
+Date: 2026-05-14
 Authors@R: 
     c(person("Licheng", "Liu", , "lichengl@stanford.edu", role = c("aut")), 
       person("Ziyi", "Liu", , "zyliu2023@berkeley.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
 <!-- markdownlint-disable MD025 -->
+# fect 2.4.3
+
+* Fix `future.globals.maxSize` overrun in parallel bootstrap: `quiet_nonpara`
+  wrapper no longer captures `fect_boot()`'s full frame.
+* Raise `future.globals.maxSize` to 2 GiB locally inside the parallel block.
+
 # fect 2.4.2
 
 ## New: `ci.method` argument on `fect()`; legacy `quantile.CI` soft-deprecated

--- a/R/boot.R
+++ b/R/boot.R
@@ -1640,9 +1640,23 @@ fect_boot <- function(
     options(doFuture.rng.onMisuse = "ignore")
     on.exit(options(doFuture.rng.onMisuse = old_rng_misuse), add = TRUE)
 
+    ## v2.4.3: bump future.globals.maxSize locally to 2 GiB for the
+    ## parallel block. Belt-and-braces guard for very large panels
+    ## (high N*T, large factor rank, dense covariates) whose per-worker
+    ## export can exceed the 500 MiB default even after the trim below.
+    ## Honour any larger user-set cap via max().
+    old_future_max <- getOption("future.globals.maxSize", 500 * 1024^2)
+    options(future.globals.maxSize = max(old_future_max, 2 * 1024^3))
+    on.exit(options(future.globals.maxSize = old_future_max), add = TRUE)
+
     quiet_nonpara <- function(j) {
       suppressMessages(suppressWarnings(one.nonpara(boot.seq[j])))
     }
+    ## v2.4.3: trim the wrapper's closure env so foreach/future export
+    ## ships only `one.nonpara` (already trimmed at L1600) and `boot.seq`,
+    ## NOT the full fect_boot() frame (Y, D, X, W, out, ...). Prevents the
+    ## quiet_nonpara=728MiB blowup reported on IFE + nboots=1000.
+    quiet_nonpara <- trim_closure_env(quiet_nonpara)
 
     run_dopar_retry <- function(idx, workers) {
       ## Build the PSOCK cluster via the package helper, which bakes

--- a/tests/testthat/test-cv-parallel.R
+++ b/tests/testthat/test-cv-parallel.R
@@ -1761,3 +1761,103 @@ test_that("N.6: plan restored after sequential IFE and CFE nevertreated parallel
   expect_equal(plan_before, plan_after,
     info = "plan should be restored to sequential after CFE nevertreated parallel CV")
 })
+
+
+## =================================================================
+## Section B: v2.4.3 — quiet_nonpara closure-leak regression
+## =================================================================
+
+## -- B.1  Parallel bootstrap on simdata under a tight future.globals.maxSize
+##         cap. With the v2.4.3 trim of quiet_nonpara and the local 2 GiB
+##         bump, no "future.globals.maxSize" warning should fire even when
+##         the caller's pre-block cap is small.
+
+test_that("B.1: parallel bootstrap on simdata does not trip future.globals.maxSize", {
+
+  skip_on_cran()
+
+  ## Force a tight pre-block cap to simulate the failure environment.
+  ## The v2.4.3 local bump inside do_parallel_boot raises this to 2 GiB
+  ## for the duration of the parallel block (with on.exit restore).
+  old_max <- getOption("future.globals.maxSize", 500 * 1024^2)
+  options(future.globals.maxSize = 50 * 1024^2)  # 50 MiB pre-block
+  on.exit(options(future.globals.maxSize = old_max), add = TRUE)
+
+  ## Clear leaked plan state (defensive, mirrors E.6 / E.7).
+  suppressWarnings({
+    try(future::plan(future::sequential), silent = TRUE)
+    try(foreach::registerDoSEQ(),         silent = TRUE)
+  })
+
+  warns <- character(0)
+
+  expect_no_error(
+    withCallingHandlers(
+      {
+        set.seed(42)
+        suppressMessages(
+          fect::fect(
+            Y ~ D,
+            data      = simdata,
+            index     = c("id", "time"),
+            method    = "ife",
+            r         = 1,
+            CV        = FALSE,
+            se        = TRUE,
+            vartype   = "bootstrap",
+            nboots    = 20,
+            parallel  = TRUE
+          )
+        )
+      },
+      warning = function(w) {
+        warns <<- c(warns, conditionMessage(w))
+        invokeRestart("muffleWarning")
+      }
+    )
+  )
+
+  expect_false(any(grepl("future\\.globals\\.maxSize", warns)),
+               info = paste("warns:", paste(warns, collapse = " | ")))
+  expect_false(any(grepl("Future backend failed", warns)),
+               info = paste("warns:", paste(warns, collapse = " | ")))
+})
+
+## -- B.2  Structural contract: trim_closure_env(), when applied to a
+##         quiet_nonpara-shaped wrapper defined inside a heavy outer
+##         frame, keeps ONLY the two referenced locals (one.nonpara,
+##         boot.seq) and drops the rest. Locks in the invariant the
+##         v2.4.3 fix depends on.
+
+test_that("B.2: trim_closure_env strips fect_boot frame from quiet_nonpara-shape closure", {
+
+  ## Reproduce the shape of fect_boot()'s local frame: heavy locals
+  ## around a wrapper that only references `one.nonpara` and `boot.seq`.
+  outer_fn <- function() {
+    Y           <- matrix(rnorm(1e4), 100, 100)
+    D           <- matrix(rnorm(1e4), 100, 100)
+    big_out     <- as.list(seq_len(1e4))
+    boot.seq    <- 1:20
+    one.nonpara <- function(j) j
+    quiet_nonpara <- function(j) {
+      suppressMessages(suppressWarnings(one.nonpara(boot.seq[j])))
+    }
+    quiet_nonpara <- fect:::trim_closure_env(quiet_nonpara)
+    quiet_nonpara
+  }
+
+  qn <- outer_fn()
+  env_names <- ls(environment(qn), all.names = TRUE)
+
+  ## The trimmed env should hold ONLY the two referenced locals.
+  expect_setequal(env_names, c("one.nonpara", "boot.seq"))
+
+  ## And it should NOT carry the heavy frame objects.
+  expect_false("Y"       %in% env_names)
+  expect_false("D"       %in% env_names)
+  expect_false("big_out" %in% env_names)
+
+  ## Size sanity: trimmed closure stays small (< 1 MiB).
+  expect_lt(as.numeric(object.size(qn)), 1 * 1024^2)
+})
+

--- a/vignettes/bb-updates.Rmd
+++ b/vignettes/bb-updates.Rmd
@@ -1,5 +1,13 @@
 # Changelog {.unnumbered}
 
+## v2.4.3
+
+(2026-05-14)
+
+* Fix `future.globals.maxSize` overrun in parallel bootstrap: `quiet_nonpara`
+  wrapper no longer captures `fect_boot()`'s full frame.
+* Raise `future.globals.maxSize` to 2 GiB locally inside the parallel block.
+
 ## v2.4.2
 
 (2026-05-02)


### PR DESCRIPTION
## Summary

- Trims `quiet_nonpara`'s closure env inside `fect_boot()` so foreach/future export ships ~7 MiB per worker instead of 728 MiB. Reported by external user Álvaro Fernández Junquera on dev v2.4.2 (IFE + parallel + nboots=1000 tripped the 500 MiB `future.globals.maxSize` default).
- Belt-and-braces: locally bump `future.globals.maxSize` to `max(user_set, 2 GiB)` with `on.exit` restore. Honours any larger user cap.
- Universal across all three `one.nonpara` definitions and all methods (gsynth/ife/mc/cfe); IFE hit it first because its frame is largest. Bug existed because the inner wrapper replaced the already-trimmed `one.nonpara` as the iter function, undoing the L1600 trim.

## Diff

Two surgical inserts in `R/boot.R`, inside `if (do_parallel_boot)`. `codetools::findGlobals` confirms the wrapper body only references `one.nonpara` and `boot.seq` — `suppress*` calls resolve via the parent env chain, so the trim is safe.

| file | change |
| --- | --- |
| `DESCRIPTION` | 2.4.2 → 2.4.3; Date 2026-05-14 |
| `NEWS.md` | new `# fect 2.4.3` header, 2-bullet entry |
| `R/boot.R` | 14 lines: trim_closure_env + maxSize bump |
| `tests/testthat/test-cv-parallel.R` | +100 lines, Section B (B.1 + B.2) |
| `vignettes/bb-updates.Rmd` | v2.4.3 changelog entry |

## Out of scope

Not touched: the doFuture → doParallel → sequential fallback cascade, the three `one.nonpara` definitions, `trim_closure_env` itself, foreach `.export` lists.

## Test plan

- [x] `R CMD INSTALL --no-inst --preclean .` clean
- [x] `test-cv-parallel.R` isolated run: pass=77 fail=5 (the 5 fails are pre-existing banner-string tests S.1/S.2/T.2/M.2/C.2, confirmed by baseline stash + rerun)
- [x] B.1: IFE bootstrap on simdata under a tight 50 MiB pre-block cap — no `future.globals.maxSize` warning fires
- [x] B.2: structural contract — `trim_closure_env` applied to a `quiet_nonpara`-shaped wrapper keeps ONLY {one.nonpara, boot.seq}, size <1 MiB
- [x] All other boot-related test files green
- [x] Reviewer to confirm closure-env trim is safe under all four method branches (the wrapper is shared)